### PR TITLE
HTML (EEx/HEEx/Surface): Refactor syntaxes

### DIFF
--- a/syntaxes/Elixir (EEx).sublime-syntax
+++ b/syntaxes/Elixir (EEx).sublime-syntax
@@ -20,10 +20,10 @@ contexts:
   # An issue that remains is that "<% ... %>" embeds are not independent
   # of the surroundings.
   prototype:
-    - include: eex_begin_tag
-    - include: eex_end_tag
+    - include: eex-begin
+    - include: eex-end
 
-  eex_begin_tag:
+  eex-begin:
     - match: (<%)(#)
       captures:
         1: punctuation.section.embedded.begin.eex
@@ -38,7 +38,7 @@ contexts:
       #   - match: (?=%>|<%)
       #     pop: true
 
-  eex_end_tag:
+  eex-end:
     - match: \s*(%>)
       captures:
         1: punctuation.section.embedded.end.eex

--- a/syntaxes/Elixir (EEx).sublime-syntax
+++ b/syntaxes/Elixir (EEx).sublime-syntax
@@ -24,10 +24,14 @@ contexts:
     - include: eex_end_tag
 
   eex_begin_tag:
-    - match: (<)(%(?>%=?|[=/|]?))
+    - match: (<%)(#)
       captures:
-        1: punctuation.section.embedded.begin.ex.eex
-        2: entity.name.tag.ex.eex
+        1: punctuation.section.embedded.begin.eex
+        2: comment.block.eex punctuation.definition.comment.begin.eex
+      push: HTML (EEx).sublime-syntax#eex-interpolation-comment-content-pop
+
+    - match: <%(?:%=?|[=/|]?)
+      scope: punctuation.section.embedded.begin.eex
       # # NB: causes "context sanity limit" error.
       # push: core_syntax
       # with_prototype:
@@ -35,7 +39,6 @@ contexts:
       #     pop: true
 
   eex_end_tag:
-    - match: \s*(%)(>)
+    - match: \s*(%>)
       captures:
-        1: entity.name.tag.ex.eex
-        2: punctuation.section.embedded.end.ex.eex
+        1: punctuation.section.embedded.end.eex

--- a/syntaxes/Elixir (EEx).sublime-syntax
+++ b/syntaxes/Elixir (EEx).sublime-syntax
@@ -1,13 +1,19 @@
 %YAML 1.2
 ---
-version: 2
 name: Elixir (EEx)
 scope: source.elixir.eex
+version: 2
+
 extends: Elixir.sublime-syntax
 
-file_extensions: [ex.eex, exs.eex]
+file_extensions:
+  - ex.eex
+  - exs.eex
+
 first_line_match: ^#\s*exs?\.eex
-authors: [Aziz Köksal <aziz.koeksal@gmail.com>]
+
+authors:
+  - Aziz Köksal <aziz.koeksal@gmail.com>
 
 contexts:
   # Use prototype to work around the "context sanity limit" error.

--- a/syntaxes/Elixir.sublime-syntax
+++ b/syntaxes/Elixir.sublime-syntax
@@ -1,11 +1,14 @@
 %YAML 1.2
 ---
-version: 2
 # http://www.sublimetext.com/docs/3/syntax.html
 name: Elixir
 scope: source.elixir
+version: 2
 
-file_extensions: [ex, exs]
+file_extensions:
+  - ex
+  - exs
+
 first_line_match: ^#!\s*/.*\b(?:elixirc?|iex)
 
 authors:

--- a/syntaxes/HTML (EEx).sublime-syntax
+++ b/syntaxes/HTML (EEx).sublime-syntax
@@ -50,7 +50,7 @@ contexts:
     - clear_scopes: 1  # clear string scope
     - meta_include_prototype: false
     - meta_scope: meta.embedded.eex
-    - meta_content_scope: source.elixir.embedded.html
+    - meta_content_scope: source.elixir.embedded.eex
     - include: eex-embedded-content-pop
 
   eex-embedded:
@@ -74,7 +74,7 @@ contexts:
   eex-embedded-content-pop:
     - meta_include_prototype: false
     - meta_scope: meta.embedded.eex
-    - meta_content_scope: source.elixir.embedded.html
+    - meta_content_scope: source.elixir.embedded.eex
     - include: eex-embedded-end-pop
     - include: scope:source.elixir
       apply_prototype: true

--- a/syntaxes/HTML (EEx).sublime-syntax
+++ b/syntaxes/HTML (EEx).sublime-syntax
@@ -34,56 +34,56 @@ contexts:
   eex-interpolations:
     - match: (<%)(#)
       captures:
-        1: punctuation.section.embedded.begin.eex
+        1: punctuation.section.embedded.begin.html
         2: comment.block.eex punctuation.definition.comment.begin.eex
       push: eex-interpolation-comment-content-pop
 
     # Tags <%/ and <%| are parsed but have no functionality in EEx yet.
     - match: <%(?:%=?|[=/|]?)
-      scope: punctuation.section.embedded.begin.eex
+      scope: punctuation.section.embedded.begin.html
       push: eex-interpolation-tag-content-pop
 
   eex-interpolation-comment-content-pop:
     - clear_scopes: 1  # clear string scope
     - meta_include_prototype: false
-    - meta_scope: meta.embedded.eex
+    - meta_scope: meta.embedded.html
     - meta_content_scope: comment.block.eex
     - include: eex-comment-content-pop
 
   eex-interpolation-tag-content-pop:
     - clear_scopes: 1  # clear string scope
     - meta_include_prototype: false
-    - meta_scope: meta.embedded.eex
-    - meta_content_scope: source.elixir.embedded.eex
+    - meta_scope: meta.embedded.html
+    - meta_content_scope: source.elixir.embedded.html
     - include: eex-embedded-content-pop
 
   eex-embedded:
     - match: (<%)(#)
       captures:
-        1: punctuation.section.embedded.begin.eex
+        1: punctuation.section.embedded.begin.html
         2: comment.block.eex punctuation.definition.comment.begin.eex
       push: eex-comment-content-pop
 
     # Tags <%/ and <%| are parsed but have no functionality in EEx yet.
     - match: <%(?:%=?|[=/|]?)
-      scope: punctuation.section.embedded.begin.eex
+      scope: punctuation.section.embedded.begin.html
       push: eex-embedded-content-pop
 
   eex-comment-content-pop:
     - meta_include_prototype: false
-    - meta_scope: meta.embedded.eex
+    - meta_scope: meta.embedded.html
     - meta_content_scope: comment.block.eex
     - include: eex-embedded-end-pop
 
   eex-embedded-content-pop:
     - meta_include_prototype: false
-    - meta_scope: meta.embedded.eex
-    - meta_content_scope: source.elixir.embedded.eex
+    - meta_scope: meta.embedded.html
+    - meta_content_scope: source.elixir.embedded.html
     - include: eex-embedded-end-pop
     - include: scope:source.elixir
       apply_prototype: true
 
   eex-embedded-end-pop:
     - match: '%>'
-      scope: punctuation.section.embedded.end.eex
+      scope: punctuation.section.embedded.end.html
       pop: 1

--- a/syntaxes/HTML (EEx).sublime-syntax
+++ b/syntaxes/HTML (EEx).sublime-syntax
@@ -6,51 +6,80 @@ scope: text.html.eex
 extends: Packages/HTML/HTML.sublime-syntax
 
 file_extensions: [html.eex, html.leex]
-authors: [Aziz Köksal <aziz.koeksal@gmail.com>]
+authors:
+  - Aziz Köksal <aziz.koeksal@gmail.com>
+  - deathaxe <https://github.com/deathaxe>
 
 contexts:
   # HTML:
 
   prototype:
     - meta_prepend: true
-    - include: eex-tags
+    - include: eex-embedded
 
   tag-attribute-value-content:
     - meta_prepend: true
-    - include: eex-tags
+    - include: eex-interpolations
 
   strings-common-content:
     - meta_prepend: true
-    - include: eex-tags
+    - include: eex-interpolations
 
   # EEx:
 
-  eex-tags:
-    - match: <%#
-      scope: punctuation.definition.comment.begin.eex
-      push:
-        - meta_scope: text.html.eex comment.block.eex
-        - match: '%>'
-          scope: punctuation.definition.comment.end.eex
-          pop: 1
-
-    # Tags <%/ and <%| are parsed but have no functionality in EEx yet.
-    - match: (<)(%(?>%=?|[=/|]?))
+  eex-interpolations:
+    - match: (<%)(#)
       captures:
         1: punctuation.section.embedded.begin.eex
-        2: entity.name.tag.eex
-      push:
-        - meta_scope: meta.interpolation.eex text.html.eex
-        - clear_scopes: 1
-        - include: eex-closing-tag-punctuation-pop
-        # - include: scope:source.elixir.eex
-        - include: scope:source.elixir
-          apply_prototype: true
+        2: comment.block.eex punctuation.definition.comment.begin.eex
+      push: eex-interpolation-comment-content-pop
 
-  eex-closing-tag-punctuation-pop:
-    - match: (%)(>)
-      scope: text.html.eex
+    # Tags <%/ and <%| are parsed but have no functionality in EEx yet.
+    - match: <%(?:%=?|[=/|]?)
+      scope: punctuation.section.embedded.begin.eex
+      push: eex-interpolation-tag-content-pop
+
+  eex-interpolation-comment-content-pop:
+    - clear_scopes: 1  # clear string scope
+    - meta_include_prototype: false
+    - meta_scope: meta.embedded.eex
+    - meta_content_scope: comment.block.eex
+    - include: eex-comment-content-pop
+
+  eex-interpolation-tag-content-pop:
+    - clear_scopes: 1  # clear string scope
+    - meta_include_prototype: false
+    - meta_scope: meta.embedded.eex
+    - meta_content_scope: source.elixir.embedded.html
+    - include: eex-embedded-content-pop
+
+  eex-embedded:
+    - match: (<%)(#)
       captures:
-        1: entity.name.tag.eex
-        2: punctuation.section.embedded.end.eex
+        1: punctuation.section.embedded.begin.eex
+        2: comment.block.eex punctuation.definition.comment.begin.eex
+      push: eex-comment-content-pop
+
+    # Tags <%/ and <%| are parsed but have no functionality in EEx yet.
+    - match: <%(?:%=?|[=/|]?)
+      scope: punctuation.section.embedded.begin.eex
+      push: eex-embedded-content-pop
+
+  eex-comment-content-pop:
+    - meta_include_prototype: false
+    - meta_scope: meta.embedded.eex
+    - meta_content_scope: comment.block.eex
+    - include: eex-embedded-end-pop
+
+  eex-embedded-content-pop:
+    - meta_include_prototype: false
+    - meta_scope: meta.embedded.eex
+    - meta_content_scope: source.elixir.embedded.html
+    - include: eex-embedded-end-pop
+    - include: scope:source.elixir
+      apply_prototype: true
+
+  eex-embedded-end-pop:
+    - match: '%>'
+      scope: punctuation.section.embedded.end.eex
       pop: 1

--- a/syntaxes/HTML (EEx).sublime-syntax
+++ b/syntaxes/HTML (EEx).sublime-syntax
@@ -1,11 +1,15 @@
 %YAML 1.2
 ---
-version: 2
 name: HTML (EEx)
 scope: text.html.eex
+version: 2
+
 extends: Packages/HTML/HTML.sublime-syntax
 
-file_extensions: [html.eex, html.leex]
+file_extensions:
+  - html.eex
+  - html.leex
+
 authors:
   - Aziz Köksal <aziz.koeksal@gmail.com>
   - deathaxe <https://github.com/deathaxe>

--- a/syntaxes/HTML (HEEx).sublime-syntax
+++ b/syntaxes/HTML (HEEx).sublime-syntax
@@ -16,7 +16,7 @@ authors:
 variables:
   heex_tag_char: '[^ \n."''/=<>\x{7F}-\x{9F}]'
   heex_tag_name: '[A-Z]{{heex_tag_char}}*'
-  is_heex_tag_name_begin: (?=[.A-Z])
+  heex_slot_name: ':[a-zA-Z]{{heex_tag_char}}*'
 
 contexts:
   # HTML overrides:
@@ -57,12 +57,15 @@ contexts:
   # HEEx:
 
   heex-tags:
-    - match: <{{is_heex_tag_name_begin}}
-      scope: punctuation.definition.tag.begin.html
+    - match: (<)({{heex_tag_name}}|{{heex_slot_name}}|(?=\.))
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.begin.heex
       push: [heex-begin-tag-content-pop, heex-begin-tag-name-pop]
-
-    - match: </{{is_heex_tag_name_begin}}
-      scope: punctuation.definition.tag.begin.html
+    - match: (</)({{heex_tag_name}}|{{heex_slot_name}}|(?=\.))
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.end.heex
       push: [heex-end-tag-content-pop, heex-end-tag-name-pop]
 
   heex-begin-tag-content-pop:

--- a/syntaxes/HTML (HEEx).sublime-syntax
+++ b/syntaxes/HTML (HEEx).sublime-syntax
@@ -6,143 +6,101 @@ scope: text.html.heex
 extends: Packages/HTML/HTML.sublime-syntax
 
 file_extensions: [heex]
-authors: [Aziz Köksal <aziz.koeksal@gmail.com>]
+authors:
+  - Aziz Köksal <aziz.koeksal@gmail.com>
+  - deathaxe <https://github.com/deathaxe>
 
 variables:
-  tag_char: (?:[^ \n."'/=<>\x{7F}-\x{9F}])
-  upcase_tag_name: '[A-Z]{{tag_char}}*'
+  heex_tag_char: '[^ \n."''/=<>\x{7F}-\x{9F}]'
+  heex_tag_name: '[A-Z]{{heex_tag_char}}*'
+  is_heex_tag_name_begin: (?=[.A-Z])
 
 contexts:
   # HTML overrides:
 
-  tag:
+  tag-other:
     - meta_prepend: true
-    - include: heex-html-tag
-    - include: heex-tag
+    - include: heex-tags
+    - include: HTML (EEx).sublime-syntax#eex-embedded
 
-  tag-other-name:
+  tag-generic-attribute-name:
     - meta_prepend: true
-    - include: elixir-interpolated
-
-  tag-attributes:
-    - meta_prepend: true
-    - include: elixir-interpolated
+    - include: elixir-string-interpolation
 
   tag-attribute-value-content:
     - meta_prepend: true
-    - include: elixir-interpolated
+    - include: elixir-string-interpolation
 
   strings-common-content:
     - meta_prepend: true
-    - include: elixir-interpolated
+    - include: elixir-string-interpolation
 
   comment-content:
     - meta_prepend: true
-    - include: elixir-interpolated
+    - include: elixir-interpolation
 
   # HEEx:
 
-  heex-html-tag:
-    - match: (<)(?>(?=\.)|({{upcase_tag_name}}))
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.begin.heex
-      push: [heex-begin-tag-rest-pop, heex-begin-tag-name-rest-pop]
+  heex-tags:
+    - match: <{{is_heex_tag_name_begin}}
+      scope: punctuation.definition.tag.begin.html
+      push: [heex-begin-tag-content-pop, heex-begin-tag-name-pop]
 
-    - match: (</)(?>(?=\.)|({{upcase_tag_name}}))
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.end.heex
-      push: [heex-end-tag-rest-pop, heex-end-tag-name-rest-pop]
+    - match: </{{is_heex_tag_name_begin}}
+      scope: punctuation.definition.tag.begin.html
+      push: [heex-end-tag-content-pop, heex-end-tag-name-pop]
 
-  heex-begin-tag-rest-pop:
-    - match: /?>
-      scope: punctuation.definition.tag.end.html
-      pop: 1
+  heex-begin-tag-content-pop:
+    - meta_scope: meta.tag.other.heex
+    - include: tag-end-maybe-self-closing
     - include: tag-attributes
-      apply_prototype: true
 
-  heex-end-tag-rest-pop:
-    - match: \>|(?=\S)
-      scope: punctuation.definition.tag.end.html
+  heex-end-tag-content-pop:
+    - meta_scope: meta.tag.other.heex
+    - include: tag-end
+    - include: else-pop
+
+  heex-begin-tag-name-pop:
+    - match: '{{heex_tag_name}}'
+      scope: entity.name.tag.begin.heex
+    - include: heex-tag-name-common-pop
+
+  heex-end-tag-name-pop:
+    - match: '{{heex_tag_name}}'
+      scope: entity.name.tag.end.heex
+    - include: heex-tag-name-common-pop
+
+  heex-tag-name-common-pop:
+    - match: '[[:lower:]_]\w*[?!]?'
+      scope: variable.function.heex
       pop: 1
-
-  heex-begin-tag-name-rest-pop:
     - match: \.
       scope: punctuation.accessor.dot.heex
-      push:
-        - match: (?>[[:lower:]_]\w*+[?!]?+)
-          scope: variable.function.heex
-          pop: 2
-        - match: '{{upcase_tag_name}}|(?=\S)'
-          scope: entity.name.tag.begin.heex
-          pop: 1
-    - match: (?=\S)
-      pop: 1
-
-  heex-end-tag-name-rest-pop:
-    - match: \.
-      scope: punctuation.accessor.dot.heex
-      push:
-        - match: (?>[[:lower:]_]\w*+[?!]?+)
-          scope: variable.function.heex
-          pop: 2
-        - match: '{{upcase_tag_name}}|(?=\S)'
-          scope: entity.name.tag.end.heex
-          pop: 1
-    - match: (?=\S)
-      pop: 1
-
-  heex-tag:
-    - match: <%#
-      scope: punctuation.definition.comment.begin.eex
-      push:
-        - meta_scope: text.html.eex comment.block.eex
-        - match: '%>'
-          scope: punctuation.definition.comment.end.eex
-          pop: 1
-
-    # - match: (<)(%%=)
-    #   captures:
-    #     1: punctuation.section.embedded.begin.eex
-    #     2: entity.name.tag.eex
-    #   push:
-    #     - meta_scope: meta.interpolation.eex text.html.eex
-    #     - clear_scopes: 1
-    #     - include: heex-closing-tag-punctuation-pop
-    #     - include: scope:source.elixir.eex
-    #       apply_prototype: true
-
-    # Tags <%/ and <%| are parsed but have no functionality in EEx yet.
-    - match: (<)(%(?>%=?|[=/|]?))
-      captures:
-        1: punctuation.section.embedded.begin.eex
-        2: entity.name.tag.eex
-      push:
-        - meta_scope: meta.interpolation.eex text.html.eex
-        - clear_scopes: 1
-        - include: heex-closing-tag-punctuation-pop
-        - include: scope:source.elixir
-          apply_prototype: true
-
-  heex-closing-tag-punctuation-pop:
-    - match: (%)(>)
-      scope: text.html.eex
-      captures:
-        1: entity.name.tag.eex
-        2: punctuation.section.embedded.end.eex
-      pop: 1
+    - include: immediately-pop
 
   # Elixir:
 
-  elixir-interpolated:
+  elixir-interpolation:
     - match: \{
       scope: punctuation.section.interpolation.begin.elixir
-      push:
-        - clear_scopes: 1
-        - meta_scope: meta.interpolation.html source.elixir.interpolated.html
-        - match: \}
-          scope: punctuation.section.interpolation.end.elixir
-          pop: 1
-        - include: scope:source.elixir
-          apply_prototype: true
+      push: elixir-interpolation-content-pop
+
+  elixir-interpolation-content-pop:
+    - meta_scope: meta.interpolation.html
+    - meta_content_scope: source.elixir.interpolated.html
+    - match: \}
+      scope: punctuation.section.interpolation.end.elixir
+      pop: 1
+    - include: scope:source.elixir
+      apply_prototype: true
+
+  elixir-string-interpolation:
+    - match: \{
+      scope: punctuation.section.interpolation.begin.elixir
+      push: elixir-string-interpolation-content-pop
+
+  elixir-string-interpolation-content-pop:
+    - clear_scopes: 1
+    - meta_scope: meta.interpolation.html
+    - meta_content_scope: source.elixir.interpolated.html
+    - include: elixir-interpolation-content-pop

--- a/syntaxes/HTML (HEEx).sublime-syntax
+++ b/syntaxes/HTML (HEEx).sublime-syntax
@@ -21,26 +21,38 @@ variables:
 contexts:
   # HTML overrides:
 
+  comment-content:
+    - meta_prepend: true
+    - include: elixir-embedded
+
   tag-other:
     - meta_prepend: true
     - include: heex-tags
     - include: HTML (EEx).sublime-syntax#eex-embedded
 
-  tag-generic-attribute-name:
+  tag-class-attribute-value:
     - meta_prepend: true
-    - include: elixir-interpolation
+    - include: elixir-embedded-pop
 
-  tag-attribute-value-content:
+  tag-event-attribute-value:
     - meta_prepend: true
-    - include: elixir-interpolation
+    - include: elixir-embedded-pop
 
-  strings-common-content:
+  tag-generic-attribute-value:
     - meta_prepend: true
-    - include: elixir-interpolation
+    - include: elixir-embedded-pop
 
-  comment-content:
+  tag-href-attribute-value:
     - meta_prepend: true
-    - include: elixir-embedded
+    - include: elixir-embedded-pop
+
+  tag-id-attribute-value:
+    - meta_prepend: true
+    - include: elixir-embedded-pop
+
+  tag-style-attribute-value:
+    - meta_prepend: true
+    - include: elixir-embedded-pop
 
   # HEEx:
 
@@ -88,6 +100,11 @@ contexts:
       scope: punctuation.section.embedded.begin.heex
       push: elixir-embedded-content-pop
 
+  elixir-embedded-pop:
+    - match: \{
+      scope: punctuation.section.embedded.begin.heex
+      set: elixir-embedded-content-pop
+
   elixir-embedded-content-pop:
     - meta_scope: meta.embedded.heex
     - meta_content_scope: source.elixir.embedded.heex
@@ -96,14 +113,3 @@ contexts:
       pop: 1
     - include: scope:source.elixir
       apply_prototype: true
-
-  elixir-interpolation:
-    - match: \{
-      scope: punctuation.section.embedded.begin.heex
-      push: elixir-interpolation-content-pop
-
-  elixir-interpolation-content-pop:
-    - clear_scopes: 1
-    - meta_scope: meta.embedded.heex
-    - meta_content_scope: source.elixir.embedded.heex
-    - include: elixir-embedded-content-pop

--- a/syntaxes/HTML (HEEx).sublime-syntax
+++ b/syntaxes/HTML (HEEx).sublime-syntax
@@ -25,19 +25,19 @@ contexts:
 
   tag-generic-attribute-name:
     - meta_prepend: true
-    - include: elixir-string-interpolation
+    - include: elixir-interpolation
 
   tag-attribute-value-content:
     - meta_prepend: true
-    - include: elixir-string-interpolation
+    - include: elixir-interpolation
 
   strings-common-content:
     - meta_prepend: true
-    - include: elixir-string-interpolation
+    - include: elixir-interpolation
 
   comment-content:
     - meta_prepend: true
-    - include: elixir-interpolation
+    - include: elixir-embedded
 
   # HEEx:
 
@@ -80,27 +80,27 @@ contexts:
 
   # Elixir:
 
-  elixir-interpolation:
+  elixir-embedded:
     - match: \{
-      scope: punctuation.section.interpolation.begin.elixir
-      push: elixir-interpolation-content-pop
+      scope: punctuation.section.embedded.begin.heex
+      push: elixir-embedded-content-pop
 
-  elixir-interpolation-content-pop:
-    - meta_scope: meta.interpolation.html
-    - meta_content_scope: source.elixir.interpolated.html
+  elixir-embedded-content-pop:
+    - meta_scope: meta.embedded.heex
+    - meta_content_scope: source.elixir.embedded.heex
     - match: \}
-      scope: punctuation.section.interpolation.end.elixir
+      scope: punctuation.section.embedded.end.heex
       pop: 1
     - include: scope:source.elixir
       apply_prototype: true
 
-  elixir-string-interpolation:
+  elixir-interpolation:
     - match: \{
-      scope: punctuation.section.interpolation.begin.elixir
-      push: elixir-string-interpolation-content-pop
+      scope: punctuation.section.embedded.begin.heex
+      push: elixir-interpolation-content-pop
 
-  elixir-string-interpolation-content-pop:
+  elixir-interpolation-content-pop:
     - clear_scopes: 1
-    - meta_scope: meta.interpolation.html
-    - meta_content_scope: source.elixir.interpolated.html
-    - include: elixir-interpolation-content-pop
+    - meta_scope: meta.embedded.heex
+    - meta_content_scope: source.elixir.embedded.heex
+    - include: elixir-embedded-content-pop

--- a/syntaxes/HTML (HEEx).sublime-syntax
+++ b/syntaxes/HTML (HEEx).sublime-syntax
@@ -1,11 +1,14 @@
 %YAML 1.2
 ---
-version: 2
 name: HTML (HEEx)
 scope: text.html.heex
+version: 2
+
 extends: Packages/HTML/HTML.sublime-syntax
 
-file_extensions: [heex]
+file_extensions:
+  - heex
+
 authors:
   - Aziz Köksal <aziz.koeksal@gmail.com>
   - deathaxe <https://github.com/deathaxe>

--- a/syntaxes/HTML (HEEx).sublime-syntax
+++ b/syntaxes/HTML (HEEx).sublime-syntax
@@ -97,19 +97,19 @@ contexts:
 
   elixir-embedded:
     - match: \{
-      scope: punctuation.section.embedded.begin.heex
+      scope: punctuation.section.embedded.begin.html
       push: elixir-embedded-content-pop
 
   elixir-embedded-pop:
     - match: \{
-      scope: punctuation.section.embedded.begin.heex
+      scope: punctuation.section.embedded.begin.html
       set: elixir-embedded-content-pop
 
   elixir-embedded-content-pop:
-    - meta_scope: meta.embedded.heex
-    - meta_content_scope: source.elixir.embedded.heex
+    - meta_scope: meta.embedded.html
+    - meta_content_scope: source.elixir.embedded.html
     - match: \}
-      scope: punctuation.section.embedded.end.heex
+      scope: punctuation.section.embedded.end.html
       pop: 1
     - include: scope:source.elixir
       apply_prototype: true

--- a/syntaxes/HTML (Surface).sublime-syntax
+++ b/syntaxes/HTML (Surface).sublime-syntax
@@ -191,42 +191,42 @@ contexts:
   surface-blocks:
     - match: ({/)(?:(case|elseif|else|if|unless)|(for)|([a-z]+))(})
       captures:
-        0: meta.embedded.surface
-        1: punctuation.section.embedded.begin.surface
+        0: meta.embedded.html
+        1: punctuation.section.embedded.begin.html
         2: keyword.control.conditional.surface
         3: keyword.control.loop.surface
         4: keyword.control.surface
-        5: punctuation.section.embedded.end.surface
+        5: punctuation.section.embedded.end.html
     - match: ({#)(match)\b
       captures:
-        1: punctuation.section.embedded.begin.surface
+        1: punctuation.section.embedded.begin.html
         2: keyword.control.conditional.surface
       push: surface-match-block-content-pop
     - match: ({#)(?:(case|elseif|else|if|unless)|(for)|([a-z]+))\b
       captures:
-        1: punctuation.section.embedded.begin.surface
+        1: punctuation.section.embedded.begin.html
         2: keyword.control.conditional.surface
         3: keyword.control.loop.surface
         4: keyword.control.surface
       push: surface-conditional-block-content-pop
 
   surface-conditional-block-content-pop:
-    - meta_scope: meta.embedded.surface
-    - meta_content_scope: source.elixir.embedded.surface
+    - meta_scope: meta.embedded.html
+    - meta_content_scope: source.elixir.embedded.html
     - include: surface-block-end-pop
     - include: scope:source.elixir#arguments_ws
       apply_prototype: true
 
   surface-match-block-content-pop:
-    - meta_scope: meta.embedded.surface
-    - meta_content_scope: source.elixir.embedded.surface
+    - meta_scope: meta.embedded.html
+    - meta_content_scope: source.elixir.embedded.html
     - include: surface-block-end-pop
     - include: scope:source.elixir#parameters
       apply_prototype: true
 
   surface-block-end-pop:
     - match: \}
-      scope: punctuation.section.embedded.end.surface
+      scope: punctuation.section.embedded.end.html
       pop: 1
 
   surface-comment:
@@ -235,7 +235,7 @@ contexts:
       push: surface-comment-content-pop
 
   surface-comment-content-pop:
-    - meta_scope: meta.embedded.surface comment.block.surface
+    - meta_scope: meta.embedded.html comment.block.surface
     - match: --}
       scope: punctuation.definition.comment.end.surface
       pop: 1
@@ -243,20 +243,7 @@ contexts:
   # Elixir:
 
   elixir-embedded:
-    - match: \{
-      scope: punctuation.section.embedded.begin.surface
-      push: elixir-embedded-content-pop
+    - include: HTML (HEEx).sublime-syntax#elixir-embedded
 
   elixir-embedded-pop:
-    - match: \{
-      scope: punctuation.section.embedded.begin.surface
-      set: elixir-embedded-content-pop
-
-  elixir-embedded-content-pop:
-    - meta_scope: meta.embedded.surface
-    - meta_content_scope: source.elixir.embedded.surface
-    - match: \}
-      scope: punctuation.section.embedded.end.surface
-      pop: 1
-    - include: scope:source.elixir
-      apply_prototype: true
+    - include: HTML (HEEx).sublime-syntax#elixir-embedded-pop

--- a/syntaxes/HTML (Surface).sublime-syntax
+++ b/syntaxes/HTML (Surface).sublime-syntax
@@ -6,199 +6,64 @@ scope: text.html.surface
 extends: Packages/HTML/HTML.sublime-syntax
 
 file_extensions: [sface]
-authors: [Aziz Köksal <aziz.koeksal@gmail.com>]
+authors:
+  - Aziz Köksal <aziz.koeksal@gmail.com>
+  - deathaxe <https://github.com/deathaxe>
 
 variables:
-  tag_char: (?:[^ \n."'/=<>\x{7F}-\x{9F}])
-  tag_name: '[a-zA-Z]{{tag_char}}*'
-  upcase_tag_name: '[A-Z]{{tag_char}}*'
+  html_custom_tag_char: '[^ \n"''/=<>\x{7F}-\x{9F}]'
+  surface_tag_char: '[^ \n."''/=<>\x{7F}-\x{9F}]'
+  surface_tag_name: '[a-zA-Z]{{surface_tag_char}}*'
+  surface_upcase_tag_name: '[A-Z]{{surface_tag_char}}*'
 
 contexts:
   # HTML overrides:
 
-  tag:
-    - meta_prepend: true
-    - include: surface-tag
-    - include: surface-block
-    - include: surface-private-comment
-    - include: elixir-embedded
-
   tag-other:
-    - meta_append: true
-    - include: html-custom-tag
-
-  tag-other-name:
-    - meta_prepend: true
-    - include: elixir-interpolated
+    - include: surface-markdown-tag
+    - include: surface-raw-tag
+    - include: surface-other-tags
+    - include: html-custom-tags
+    - include: surface-blocks
+    - include: surface-comment
+    - include: elixir-interpolation
 
   tag-attributes:
     - meta_prepend: true
-    - include: elixir-interpolated
     - include: surface-attributes
+
+  tag-generic-attribute-name:
+    - meta_prepend: true
+    - include: elixir-string-interpolation
 
   tag-attribute-value-content:
     - meta_prepend: true
-    - include: elixir-interpolated
+    - include: elixir-string-interpolation
 
   strings-common-content:
     - meta_prepend: true
-    - include: elixir-interpolated
+    - include: elixir-string-interpolation
 
   comment-content:
     - meta_prepend: true
-    - include: elixir-interpolated
+    - include: elixir-interpolation
 
-  # Surface & Elixir:
+  # Surface:
 
-  surface-tag:
-    - include: surface-raw
-    - include: surface-markdown
-
-    - match: (<)([#:]{{tag_name}}|{{upcase_tag_name}})
-      captures:
-        1: punctuation.definition.tag.begin.surface
-        2: entity.name.tag.begin.surface
-      push: [surface-begin-tag-rest-pop, surface-begin-tag-name-rest-pop]
-
-    - match: (</)([#:]{{tag_name}}|{{upcase_tag_name}})
-      captures:
-        1: punctuation.definition.tag.begin.surface
-        2: entity.name.tag.end.surface
-      push: [surface-end-tag-rest-pop, surface-end-tag-name-rest-pop]
-
-  html-custom-tag:
-    - match: (<)((?>{{tag_char}}|\.)+)
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.begin.html
-      push: [surface-begin-tag-rest-pop, surface-begin-tag-name-rest-pop]
-
-    - match: (</)((?>{{tag_char}}|\.)+)
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.end.html
-      push: [surface-end-tag-rest-pop, surface-end-tag-name-rest-pop]
-
-  surface-begin-tag-rest-pop:
-    - match: /?>
-      scope: punctuation.definition.tag.end.html
-      pop: 1
-    - include: tag-attributes
-      apply_prototype: true
-
-  surface-end-tag-rest-pop:
-    - match: \>|(?=\S)
-      scope: punctuation.definition.tag.end.html
-      pop: 1
-
-  surface-begin-tag-name-rest-pop:
-    - match: \.
-      scope: punctuation.accessor.dot.surface
-      push:
-        - match: (?>[[:lower:]_]\w*+[?!]?+)
-          scope: variable.function.surface
-          pop: 2
-        - match: '{{upcase_tag_name}}|(?=\S)'
-          scope: entity.name.tag.begin.surface
-          pop: 1
-    - match: (?=\S)
-      pop: 1
-
-  surface-end-tag-name-rest-pop:
-    - match: \.
-      scope: punctuation.accessor.dot.surface
-      push:
-        - match: (?>[[:lower:]_]\w*+[?!]?+)
-          scope: variable.function.surface
-          pop: 2
-        - match: '{{upcase_tag_name}}|(?=\S)'
-          scope: entity.name.tag.end.surface
-          pop: 1
-    - match: (?=\S)
-      pop: 1
-
-  surface-attributes:
-    - match: |-
-        (?x)
-        (:)((?>
-          if | hook | show | let | args | values
-        | on-(?>
-            click | capture-click | blur | focus | change | submit | keydown | keyup
-          | window-(?>focus | blur | keydown | keyup)
-          )
-        )){{attribute_name_break}}
-      captures:
-        1: punctuation.definition.attribute.begin.surface
-        2: entity.other.attribute-name.surface
-      push: [tag-id-attribute-meta, tag-id-attribute-assignment]
-
-  surface-block:
-    - match: ({/)([a-z]+)(})
-      scope: meta.embedded.html meta.block.tag.end.surface source.elixir.embedded.html
-      captures:
-        1: punctuation.definition.tag.begin.surface
-        2: entity.name.tag.block.surface
-        3: punctuation.definition.tag.end.surface
-    - match: ({#)(match)\b
-      captures:
-        1: punctuation.definition.tag.begin.surface
-        2: entity.name.tag.block.surface
-      push:
-        - meta_scope: meta.embedded.html meta.block.tag.begin.surface source.elixir.embedded.html
-        - include: surface-block-closing-brace-pop
-        - include: scope:source.elixir#parameters
-          apply_prototype: true
-    - match: ({#)(?>(else\b)|(elseif\b|[a-z]+))\b
-      captures:
-        1: punctuation.definition.tag.begin.surface
-        2: entity.name.tag.block.surface
-        3: entity.name.tag.block.surface
-        # 3: variable.function.surface
-      push:
-        - meta_scope: meta.embedded.html meta.block.tag.begin.surface source.elixir.embedded.html
-        - include: surface-block-closing-brace-pop
-        - include: scope:source.elixir#arguments_ws
-          apply_prototype: true
-
-  surface-block-closing-brace-pop:
-    - match: \}
-      scope: punctuation.definition.tag.end.surface
-      pop: 1
-
-  surface-raw:
-    # NB: the #Raw-tag cannot be nested, e.g.: `<#Raw><#Raw></#Raw></#Raw>`
-    - match: (<)(#Raw)(>)
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.begin.surface
-        3: punctuation.definition.tag.end.html
-      push: surface-raw-body-pop
-
-  surface-raw-body-pop:
-    - match: (</)(#Raw)\b
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.end.surface
-      set: surface-end-tag-rest-pop
-
-    - include: scope:text.html.basic
-      apply_prototype: true
-
-  surface-markdown:
+  surface-markdown-tag:
     # NB: the #Markdown-tag cannot be nested, e.g.: `<#Markdown><#Markdown></#Markdown></#Markdown>`
     - match: (<)(#Markdown)\b
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.begin.surface
-      push: [surface-markdown-attrs-pop]
+      push: surface-markdown-tag-content-pop
 
-  surface-markdown-attrs-pop:
+  surface-markdown-tag-content-pop:
+    - meta_scope: meta.tag.other.surface
     - match: \>
       scope: punctuation.definition.tag.end.html
       set: surface-markdown-body-pop
-    - match: /\>
-      scope: punctuation.definition.tag.end.html
-      pop: 1
+    - include: tag-end-self-closing
     - include: tag-attributes
 
   surface-markdown-body-pop:
@@ -206,7 +71,7 @@ contexts:
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.end.surface
-      set: surface-end-tag-rest-pop
+      set: surface-end-tag-content-pop
 
     # # NB: commented out because Markdown is not really highlighted correctly
     # #     due to the surrounding indentation.
@@ -218,42 +83,151 @@ contexts:
     - include: scope:text.html.basic
       apply_prototype: true
 
-    # # NB: cannot use apply_prototype because Markdown doesn't use version 2.
-    # - include: scope:text.html.markdown
-    #   apply_prototype: true
+  surface-raw-tag:
+    # NB: the #Raw-tag cannot be nested, e.g.: `<#Raw><#Raw></#Raw></#Raw>`
+    - match: (<)(#Raw)(>)
+      captures:
+        0: meta.tag.other.surface
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.begin.surface
+        3: punctuation.definition.tag.end.html
+      push: surface-raw-body-pop
 
-  surface-private-comment:
+  surface-raw-body-pop:
+    - match: (</)(#Raw)\b
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.end.surface
+      set: surface-end-tag-content-pop
+
+    - include: scope:text.html.basic
+      apply_prototype: true
+
+  surface-other-tags:
+    - match: (<)([#:]{{surface_tag_name}}|{{surface_upcase_tag_name}})
+      captures:
+        1: punctuation.definition.tag.begin.surface
+        2: entity.name.tag.begin.surface
+      push: [surface-begin-tag-content-pop, surface-begin-tag-name-pop]
+
+    - match: (</)([#:]{{surface_tag_name}}|{{surface_upcase_tag_name}})
+      captures:
+        1: punctuation.definition.tag.begin.surface
+        2: entity.name.tag.end.surface
+      push: [surface-end-tag-content-pop, surface-end-tag-name-pop]
+
+  html-custom-tags:
+    - match: (<)({{html_custom_tag_char}}+)
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.begin.html
+      push: surface-begin-tag-content-pop
+
+    - match: (</)({{html_custom_tag_char}}+)
+      captures:
+        1: punctuation.definition.tag.begin.html
+        2: entity.name.tag.end.html
+      push: surface-end-tag-content-pop
+
+  surface-begin-tag-content-pop:
+    - meta_scope: meta.tag.other.surface
+    - include: tag-end-maybe-self-closing
+    - include: tag-attributes
+
+  surface-end-tag-content-pop:
+    - meta_scope: meta.tag.other.surface
+    - include: tag-end
+    - include: else-pop
+
+  surface-begin-tag-name-pop:
+    - match: '{{surface_upcase_tag_name}}'
+      scope: entity.name.tag.begin.surface
+    - include: surface-tag-name-common-pop
+
+  surface-end-tag-name-pop:
+    - match: '{{surface_upcase_tag_name}}'
+      scope: entity.name.tag.end.surface
+    - include: surface-tag-name-common-pop
+
+  surface-tag-name-common-pop:
+    - match: '[[:lower:]_]\w*[?!]?'
+      scope: variable.function.surface
+      pop: 1
+    - match: \.
+      scope: punctuation.accessor.dot.surface
+    - include: immediately-pop
+
+  surface-attributes:
+    - match: |-
+        (?x)
+        (:)(
+          if | hook | show | let | args | values
+        | on-(?:
+            click | capture-click | blur | focus | change | submit | keydown | keyup
+          | window-(?:focus | blur | keydown | keyup)
+          )
+        ){{attribute_name_break}}
+      captures:
+        1: punctuation.definition.attribute.begin.surface
+        2: entity.other.attribute-name.surface
+      push: [tag-id-attribute-meta, tag-id-attribute-assignment]
+
+  surface-blocks:
+    - match: ({/)(?:(case|elseif|else|if|unless)|(for)|([a-z]+))(})
+      captures:
+        0: meta.embedded.surface
+        1: punctuation.section.embedded.begin.surface
+        2: keyword.control.conditional.surface
+        3: keyword.control.loop.surface
+        4: keyword.control.surface
+        5: punctuation.section.embedded.end.surface
+    - match: ({#)(match)\b
+      captures:
+        1: punctuation.section.embedded.begin.surface
+        2: keyword.control.conditional.surface
+      push: surface-match-block-content-pop
+    - match: ({#)(?:(case|elseif|else|if|unless)|(for)|([a-z]+))\b
+      captures:
+        1: punctuation.section.embedded.begin.surface
+        2: keyword.control.conditional.surface
+        3: keyword.control.loop.surface
+        4: keyword.control.surface
+      push: surface-conditional-block-content-pop
+
+  surface-conditional-block-content-pop:
+    - meta_scope: meta.embedded.surface
+    - meta_content_scope: source.elixir.embedded.html
+    - include: surface-block-end-pop
+    - include: scope:source.elixir#arguments_ws
+      apply_prototype: true
+
+  surface-match-block-content-pop:
+    - meta_scope: meta.embedded.surface
+    - meta_content_scope: source.elixir.embedded.html
+    - include: surface-block-end-pop
+    - include: scope:source.elixir#parameters
+      apply_prototype: true
+
+  surface-block-end-pop:
+    - match: \}
+      scope: punctuation.section.embedded.end.surface
+      pop: 1
+
+  surface-comment:
     - match: '{!--'
       scope: punctuation.definition.comment.begin.surface
-      push:
-        - meta_scope: meta.embedded.html comment.block.surface
-        - clear_scopes: 1
-        - match: --}
-          scope: punctuation.definition.comment.end.surface
-          pop: 1
+      push: surface-comment-content-pop
+
+  surface-comment-content-pop:
+    - meta_scope: meta.embedded.html comment.block.surface
+    - match: --}
+      scope: punctuation.definition.comment.end.surface
+      pop: 1
 
   # Elixir:
 
-  elixir-embedded:
-    - match: \{
-      scope: punctuation.section.embedded.begin.elixir
-      push:
-        - clear_scopes: 1
-        - meta_scope: meta.embedded.html source.elixir.embedded.html
-        - match: \}
-          scope: punctuation.section.embedded.end.elixir
-          pop: 1
-        - include: scope:source.elixir
-          # apply_prototype: true
+  elixir-interpolation:
+    - include: HTML (HEEx).sublime-syntax#elixir-interpolation
 
-  elixir-interpolated:
-    - match: \{
-      scope: punctuation.section.interpolation.begin.elixir
-      push:
-        - clear_scopes: 1
-        - meta_scope: meta.interpolation.html source.elixir.interpolated.html
-        - match: \}
-          scope: punctuation.section.interpolation.end.elixir
-          pop: 1
-        - include: scope:source.elixir
-          # apply_prototype: true
+  elixir-string-interpolation:
+    - include: HTML (HEEx).sublime-syntax#elixir-string-interpolation

--- a/syntaxes/HTML (Surface).sublime-syntax
+++ b/syntaxes/HTML (Surface).sublime-syntax
@@ -22,6 +22,10 @@ variables:
 contexts:
   # HTML overrides:
 
+  comment-content:
+    - meta_prepend: true
+    - include: elixir-embedded
+
   tag-other:
     - include: surface-markdown-tag
     - include: surface-raw-tag
@@ -34,22 +38,31 @@ contexts:
   tag-attributes:
     - meta_prepend: true
     - include: surface-attributes
-
-  tag-generic-attribute-name:
-    - meta_prepend: true
-    - include: elixir-interpolation
-
-  tag-attribute-value-content:
-    - meta_prepend: true
-    - include: elixir-interpolation
-
-  strings-common-content:
-    - meta_prepend: true
-    - include: elixir-interpolation
-
-  comment-content:
-    - meta_prepend: true
     - include: elixir-embedded
+
+  tag-class-attribute-value:
+    - meta_prepend: true
+    - include: elixir-embedded-pop
+
+  tag-event-attribute-value:
+    - meta_prepend: true
+    - include: elixir-embedded-pop
+
+  tag-generic-attribute-value:
+    - meta_prepend: true
+    - include: elixir-embedded-pop
+
+  tag-href-attribute-value:
+    - meta_prepend: true
+    - include: elixir-embedded-pop
+
+  tag-id-attribute-value:
+    - meta_prepend: true
+    - include: elixir-embedded-pop
+
+  tag-style-attribute-value:
+    - meta_prepend: true
+    - include: elixir-embedded-pop
 
   # Surface:
 
@@ -234,6 +247,11 @@ contexts:
       scope: punctuation.section.embedded.begin.surface
       push: elixir-embedded-content-pop
 
+  elixir-embedded-pop:
+    - match: \{
+      scope: punctuation.section.embedded.begin.surface
+      set: elixir-embedded-content-pop
+
   elixir-embedded-content-pop:
     - meta_scope: meta.embedded.surface
     - meta_content_scope: source.elixir.embedded.surface
@@ -242,14 +260,3 @@ contexts:
       pop: 1
     - include: scope:source.elixir
       apply_prototype: true
-
-  elixir-interpolation:
-    - match: \{
-      scope: punctuation.section.embedded.begin.surface
-      push: elixir-interpolation-content-pop
-
-  elixir-interpolation-content-pop:
-    - clear_scopes: 1
-    - meta_scope: meta.embedded.surface
-    - meta_content_scope: source.elixir.embedded.surface
-    - include: elixir-embedded-content-pop

--- a/syntaxes/HTML (Surface).sublime-syntax
+++ b/syntaxes/HTML (Surface).sublime-syntax
@@ -34,19 +34,19 @@ contexts:
 
   tag-generic-attribute-name:
     - meta_prepend: true
-    - include: elixir-string-interpolation
+    - include: elixir-interpolation
 
   tag-attribute-value-content:
     - meta_prepend: true
-    - include: elixir-string-interpolation
+    - include: elixir-interpolation
 
   strings-common-content:
     - meta_prepend: true
-    - include: elixir-string-interpolation
+    - include: elixir-interpolation
 
   comment-content:
     - meta_prepend: true
-    - include: elixir-interpolation
+    - include: elixir-embedded
 
   # Surface:
 
@@ -196,14 +196,14 @@ contexts:
 
   surface-conditional-block-content-pop:
     - meta_scope: meta.embedded.surface
-    - meta_content_scope: source.elixir.embedded.html
+    - meta_content_scope: source.elixir.embedded.surface
     - include: surface-block-end-pop
     - include: scope:source.elixir#arguments_ws
       apply_prototype: true
 
   surface-match-block-content-pop:
     - meta_scope: meta.embedded.surface
-    - meta_content_scope: source.elixir.embedded.html
+    - meta_content_scope: source.elixir.embedded.surface
     - include: surface-block-end-pop
     - include: scope:source.elixir#parameters
       apply_prototype: true
@@ -219,7 +219,7 @@ contexts:
       push: surface-comment-content-pop
 
   surface-comment-content-pop:
-    - meta_scope: meta.embedded.html comment.block.surface
+    - meta_scope: meta.embedded.surface comment.block.surface
     - match: --}
       scope: punctuation.definition.comment.end.surface
       pop: 1
@@ -229,22 +229,24 @@ contexts:
   elixir-embedded:
     - match: \{
       scope: punctuation.section.embedded.begin.surface
-      set: elixir-embedded-content-pop
+      push: elixir-embedded-content-pop
 
   elixir-embedded-content-pop:
     - meta_scope: meta.embedded.surface
-    - meta_content_scope: source.elixir.embedded.html
-    - include: elixir-embedded-end-pop
-    - include: scope:source.elixir
-      apply_prototype: true
-
-  elixir-embedded-end-pop:
+    - meta_content_scope: source.elixir.embedded.surface
     - match: \}
       scope: punctuation.section.embedded.end.surface
       pop: 1
+    - include: scope:source.elixir
+      apply_prototype: true
 
   elixir-interpolation:
-    - include: HTML (HEEx).sublime-syntax#elixir-interpolation
+    - match: \{
+      scope: punctuation.section.embedded.begin.surface
+      push: elixir-interpolation-content-pop
 
-  elixir-string-interpolation:
-    - include: HTML (HEEx).sublime-syntax#elixir-string-interpolation
+  elixir-interpolation-content-pop:
+    - clear_scopes: 1
+    - meta_scope: meta.embedded.surface
+    - meta_content_scope: source.elixir.embedded.surface
+    - include: elixir-embedded-content-pop

--- a/syntaxes/HTML (Surface).sublime-syntax
+++ b/syntaxes/HTML (Surface).sublime-syntax
@@ -26,7 +26,7 @@ contexts:
     - include: html-custom-tags
     - include: surface-blocks
     - include: surface-comment
-    - include: elixir-interpolation
+    - include: elixir-embedded
 
   tag-attributes:
     - meta_prepend: true
@@ -225,6 +225,23 @@ contexts:
       pop: 1
 
   # Elixir:
+
+  elixir-embedded:
+    - match: \{
+      scope: punctuation.section.embedded.begin.surface
+      set: elixir-embedded-content-pop
+
+  elixir-embedded-content-pop:
+    - meta_scope: meta.embedded.surface
+    - meta_content_scope: source.elixir.embedded.html
+    - include: elixir-embedded-end-pop
+    - include: scope:source.elixir
+      apply_prototype: true
+
+  elixir-embedded-end-pop:
+    - match: \}
+      scope: punctuation.section.embedded.end.surface
+      pop: 1
 
   elixir-interpolation:
     - include: HTML (HEEx).sublime-syntax#elixir-interpolation

--- a/syntaxes/HTML (Surface).sublime-syntax
+++ b/syntaxes/HTML (Surface).sublime-syntax
@@ -1,11 +1,14 @@
 %YAML 1.2
 ---
-version: 2
 name: HTML (Surface)
 scope: text.html.surface
+version: 2
+
 extends: Packages/HTML/HTML.sublime-syntax
 
-file_extensions: [sface]
+file_extensions:
+  - sface
+
 authors:
   - Aziz Köksal <aziz.koeksal@gmail.com>
   - deathaxe <https://github.com/deathaxe>

--- a/syntaxes/PCRE (Erlang).sublime-syntax
+++ b/syntaxes/PCRE (Erlang).sublime-syntax
@@ -1,11 +1,15 @@
 %YAML 1.2
 ---
+# Perl Compatible Regular Expressions with a focus on Erlang (http://erlang.org/doc/man/re.html)
 name: PCRE (Erlang)
 scope: source.pcree
-file_extensions: [pcree]
 hidden: true
-comment: Perl Compatible Regular Expressions with a focus on Erlang (http://erlang.org/doc/man/re.html)
-authors: [Aziz Köksal <aziz.koeksal@gmail.com>]
+
+file_extensions:
+  - pcree
+
+authors:
+  - Aziz Köksal <aziz.koeksal@gmail.com>
 
 variables:
   character_quantifier: '[?*+]'

--- a/syntaxes/SQL (Elixir).sublime-syntax
+++ b/syntaxes/SQL (Elixir).sublime-syntax
@@ -3,8 +3,11 @@
 name: SQL (Elixir)
 scope: source.ex.sql
 
-file_extensions: [ex.sql]
-authors: [Aziz Köksal <aziz.koeksal@gmail.com>]
+file_extensions:
+  - ex.sql
+
+authors:
+  - Aziz Köksal <aziz.koeksal@gmail.com>
 
 contexts:
   main:

--- a/tests/syntax_test_strings.ex
+++ b/tests/syntax_test_strings.ex
@@ -181,7 +181,7 @@ heredoc text
 #   ^ -string
 #^^^ entity.name.tag.block.any.html
 #               ^^^^^^ meta.string.elixir
-#    ^^^^^^^^^^^ meta.embedded.eex
+#    ^^^^^^^^^^^ meta.embedded.html
 #^^^^ meta.string.elixir
  \"""m
 #    ^ -storage.type.string

--- a/tests/syntax_test_strings.ex
+++ b/tests/syntax_test_strings.ex
@@ -181,7 +181,7 @@ heredoc text
 #   ^ -string
 #^^^ entity.name.tag.block.any.html
 #               ^^^^^^ meta.string.elixir
-#    ^^^^^^^^^^^ meta.interpolation.eex
+#    ^^^^^^^^^^^ meta.embedded.eex
 #^^^^ meta.string.elixir
  \"""m
 #    ^ -storage.type.string

--- a/tests/syntax_test_surface.ex
+++ b/tests/syntax_test_surface.ex
@@ -7,7 +7,9 @@
 #  ^^^ meta.string.elixir punctuation.definition.string.begin.elixir
 
   <Some.App.Component x={y}>
-#                       ^^^ source.elixir.interpolated.html
+#                         ^ punctuation.section.interpolation.end.elixir - source.elixir.interpolated
+#                        ^ source.elixir.interpolated.html
+#                       ^ punctuation.section.interpolation.begin.elixir - source.elixir.interpolated
 #                     ^ entity.other.attribute-name.html
 #           ^^^^^^^^^ entity.name.tag.begin.surface
 #       ^^^ entity.name.tag.begin.surface

--- a/tests/syntax_test_surface.ex
+++ b/tests/syntax_test_surface.ex
@@ -7,9 +7,9 @@
 #  ^^^ meta.string.elixir punctuation.definition.string.begin.elixir
 
   <Some.App.Component x={y}>
-#                         ^ punctuation.section.embedded.end.surface - source.elixir.embedded
-#                        ^ source.elixir.embedded.surface
-#                       ^ punctuation.section.embedded.begin.surface - source.elixir.embedded
+#                         ^ punctuation.section.embedded.end.html - source.elixir.embedded
+#                        ^ source.elixir.embedded.html
+#                       ^ punctuation.section.embedded.begin.html - source.elixir.embedded
 #                     ^ entity.other.attribute-name.html
 #           ^^^^^^^^^ entity.name.tag.begin.surface
 #       ^^^ entity.name.tag.begin.surface

--- a/tests/syntax_test_surface.ex
+++ b/tests/syntax_test_surface.ex
@@ -7,9 +7,9 @@
 #  ^^^ meta.string.elixir punctuation.definition.string.begin.elixir
 
   <Some.App.Component x={y}>
-#                         ^ punctuation.section.interpolation.end.elixir - source.elixir.interpolated
-#                        ^ source.elixir.interpolated.html
-#                       ^ punctuation.section.interpolation.begin.elixir - source.elixir.interpolated
+#                         ^ punctuation.section.embedded.end.surface - source.elixir.embedded
+#                        ^ source.elixir.embedded.surface
+#                       ^ punctuation.section.embedded.begin.surface - source.elixir.embedded
 #                     ^ entity.other.attribute-name.html
 #           ^^^^^^^^^ entity.name.tag.begin.surface
 #       ^^^ entity.name.tag.begin.surface

--- a/tests/syntax_test_template.ex.eex
+++ b/tests/syntax_test_template.ex.eex
@@ -18,15 +18,16 @@
 defmodule <%= @module %>.View do
 #                        ^^^^ entity.name.namespace
 #                       ^ punctuation.accessor.dot
-#                     ^ entity.name.tag.ex.eex
+#                     ^^ punctuation.section.embedded.end.eex
 #             ^ keyword.operator.attribute
-#          ^^ entity.name.tag.ex.eex
+#         ^^^ punctuation.section.embedded.begin.eex
 end
 
 alias <%= @web_namespace %>.Router.Helpers, as: Routes
 #                                               ^^^^^^ entity.name.namespace
 #                          ^ punctuation.accessor.dot
-#      ^^ entity.name.tag.ex.eex
+#                        ^^ punctuation.section.embedded.end.eex
+#     ^^^ punctuation.section.embedded.begin.eex
 
 :<%= @key %>
 #<- constant.other.symbol punctuation.definition.constant.begin
@@ -41,50 +42,48 @@ alias <%= @web_namespace %>.Router.Helpers, as: Routes
 #     are also highlighted inside strings.
 # FIXME: make negative check with "-entity" when solved.
 "<%= string %>"
-#           ^ entity.name.tag.ex.eex
-# ^^ entity.name.tag.ex.eex
+#           ^^ punctuation.section.embedded.end.eex
+#^^^ punctuation.section.embedded.begin.eex
 
 M1.<%= M2 %>.f()
 #              ^ punctuation.section.arguments.end
 #             ^ punctuation.section.arguments.begin
 #            ^ variable.function
 #           ^ punctuation.accessor.dot
-#         ^ entity.name.tag.ex.eex
+#         ^^ punctuation.section.embedded.end.eex
 #      ^^ constant.other.module
-#   ^^ entity.name.tag.ex.eex
+#  ^^^ punctuation.section.embedded.begin.eex
 # ^ punctuation.accessor.dot
 
 x.<%= :member %>()
 #                ^ punctuation.section.arguments.end
 #               ^ punctuation.section.arguments.begin
-#             ^ entity.name.tag.ex.eex
+#             ^^ punctuation.section.embedded.end.eex
 #     ^^^^^^^ constant.other.symbol
-#  ^^ entity.name.tag.ex.eex
+# ^^^ punctuation.section.embedded.begin.eex
 #^ punctuation.accessor.dot
                  ^ punctuation.section.arguments.end
                 ^ punctuation.section.arguments.begin
 
 @type <%= :t %> :: any
-#            ^ entity.name.tag.ex.eex
-#      ^^ entity.name.tag.ex.eex
+#            ^^ punctuation.section.embedded.end.eex
+#     ^^^ punctuation.section.embedded.begin.eex
                    ^^^ support.type
 
 @spec <%= :name %>(any)
 #                  ^^^ support.type
-#               ^ entity.name.tag.ex.eex
-#      ^^ entity.name.tag.ex.eex
+#               ^^ punctuation.section.embedded.end.eex
+#     ^^^ punctuation.section.embedded.begin.eex
                       ^ punctuation.definition.parameters.end
                   ^ punctuation.definition.parameters.begin
 
  &<%= %>
-#     ^ entity.name.tag.ex.eex
-#  ^^ entity.name.tag.ex.eex
+#     ^^ punctuation.section.embedded.end.eex
+# ^^^ punctuation.section.embedded.begin.eex
 #^ keyword.operator.capture
 
 # <%= @web_app_name %>
-#                    ^ punctuation.section.embedded.end.ex.eex
-#                   ^ entity.name.tag.ex.eex
-#  ^^ entity.name.tag.ex.eex
-# ^ punctuation.section.embedded.begin.ex.eex
+#                   ^^ punctuation.section.embedded.end.eex
+# ^^^ punctuation.section.embedded.begin.eex
 #^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign.elixir
 #<- comment.line.number-sign.elixir punctuation.definition.comment.elixir

--- a/tests/syntax_test_template.html.eex
+++ b/tests/syntax_test_template.html.eex
@@ -5,7 +5,7 @@
 <html lang="<%= "en" %>">
 <!--                   ^ meta.attribute-with-value.html meta.string.html - meta.interpolation -->
 <!--                 ^^ meta.attribute-with-value.html meta.string.html meta.embedded.eex - source -->
-<!--           ^^^^^^ meta.attribute-with-value.html meta.string.html meta.embedded.eex source.elixir.embedded.html -->
+<!--           ^^^^^^ meta.attribute-with-value.html meta.string.html meta.embedded.eex source.elixir.embedded.eex -->
 <!--        ^^^ meta.attribute-with-value.html meta.string.html meta.embedded.eex - source -->
 <!--       ^ meta.attribute-with-value.html meta.string.html - meta.interpolation -->
 <!--                   ^ punctuation.definition.string.end.html -->
@@ -30,7 +30,7 @@
 
      <% func arg %>
 <!--             ^^ text.html.eex meta.embedded.eex - source -->
-<!--   ^^^^^^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.html -->
+<!--   ^^^^^^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.eex -->
 <!-- ^^ text.html.eex meta.embedded.eex - source -->
 <!--             ^^ punctuation.section.embedded.end.eex -->
 <!--         ^^^ variable.other.elixir -->
@@ -39,7 +39,7 @@
 
      <%= if true? do %>
 <!--                 ^^ text.html.eex meta.embedded.eex - source -->
-<!--    ^^^^^^^^^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.html -->
+<!--    ^^^^^^^^^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.eex -->
 <!-- ^^^ text.html.eex meta.embedded.eex - source -->
 <!--                 ^^ punctuation.section.embedded.end.eex -->
 <!--              ^^ keyword.context.block.do.elixir -->
@@ -48,7 +48,7 @@
 <!-- ^^^ punctuation.section.embedded.begin.eex -->
      <% end %>
 <!--        ^^ text.html.eex meta.embedded.eex - source -->
-<!--   ^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.html -->
+<!--   ^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.eex -->
 <!-- ^^ text.html.eex meta.embedded.eex - source -->
 <!--        ^^ punctuation.section.embedded.end.eex -->
 <!--    ^^^ keyword.context.block.end.elixir -->
@@ -56,7 +56,7 @@
 
      <%% quoted :code %>
 <!--                  ^^ text.html.eex meta.embedded.eex - source -->
-<!--    ^^^^^^^^^^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.html -->
+<!--    ^^^^^^^^^^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.eex -->
 <!-- ^^^ text.html.eex meta.embedded.eex - source -->
 <!--                  ^^ punctuation.section.embedded.end.eex -->
 <!--            ^^^^^ constant.other.symbol.elixir -->
@@ -65,7 +65,7 @@
 
      <%%= quoted :result %>
 <!--                     ^^ text.html.eex meta.embedded.eex - source -->
-<!--     ^^^^^^^^^^^^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.html -->
+<!--     ^^^^^^^^^^^^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.eex -->
 <!-- ^^^^ text.html.eex meta.embedded.eex - source -->
 <!--                     ^^ punctuation.section.embedded.end.eex -->
 <!--             ^^^^^^^ constant.other.symbol.elixir -->

--- a/tests/syntax_test_template.html.eex
+++ b/tests/syntax_test_template.html.eex
@@ -4,71 +4,71 @@
 <!-- ^^^^^^^ keyword.declaration.doctype.html -->
 <html lang="<%= "en" %>">
 <!--                   ^ meta.attribute-with-value.html meta.string.html - meta.interpolation -->
-<!--                 ^^ meta.attribute-with-value.html meta.string.html meta.embedded.eex - source -->
-<!--           ^^^^^^ meta.attribute-with-value.html meta.string.html meta.embedded.eex source.elixir.embedded.eex -->
-<!--        ^^^ meta.attribute-with-value.html meta.string.html meta.embedded.eex - source -->
+<!--                 ^^ meta.attribute-with-value.html meta.string.html meta.embedded.html - source -->
+<!--           ^^^^^^ meta.attribute-with-value.html meta.string.html meta.embedded.html source.elixir.embedded.html -->
+<!--        ^^^ meta.attribute-with-value.html meta.string.html meta.embedded.html - source -->
 <!--       ^ meta.attribute-with-value.html meta.string.html - meta.interpolation -->
 <!--                   ^ punctuation.definition.string.end.html -->
-<!--                 ^^ punctuation.section.embedded.end.eex -->
+<!--                 ^^ punctuation.section.embedded.end.html -->
 <!--            ^^^^ string.quoted.double.elixir - string string -->
-<!--        ^^^ punctuation.section.embedded.begin.eex -->
+<!--        ^^^ punctuation.section.embedded.begin.html -->
 <!--       ^ punctuation.definition.string.begin.html -->
 
      <%# Comment %>
-<!--             ^^ punctuation.section.embedded.end.eex - comment -->
+<!--             ^^ punctuation.section.embedded.end.html - comment -->
 <!--   ^^^^^^^^^^ comment.block.eex - constant -->
 <!--   ^ punctuation.definition.comment.begin.eex -->
-<!-- ^^ punctuation.section.embedded.begin.eex - comment -->
-<!-- ^^^^^^^^^^^^^^ text.html.eex meta.embedded.eex -->
+<!-- ^^ punctuation.section.embedded.begin.html - comment -->
+<!-- ^^^^^^^^^^^^^^ text.html.eex meta.embedded.html -->
 
      <br class="<%# Comment %>" />
-<!--                        ^^ punctuation.section.embedded.end.eex - comment -->
+<!--                        ^^ punctuation.section.embedded.end.html - comment -->
 <!--              ^^^^^^^^^^ comment.block.eex - constant -->
 <!--              ^ punctuation.definition.comment.begin.eex -->
-<!--            ^^ punctuation.section.embedded.begin.eex - comment -->
-<!--            ^^^^^^^^^^^^^^ text.html.eex meta.embedded.eex - string -->
+<!--            ^^ punctuation.section.embedded.begin.html - comment -->
+<!--            ^^^^^^^^^^^^^^ text.html.eex meta.embedded.html - string -->
 
      <% func arg %>
-<!--             ^^ text.html.eex meta.embedded.eex - source -->
-<!--   ^^^^^^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.eex -->
-<!-- ^^ text.html.eex meta.embedded.eex - source -->
-<!--             ^^ punctuation.section.embedded.end.eex -->
+<!--             ^^ text.html.eex meta.embedded.html - source -->
+<!--   ^^^^^^^^^^ text.html.eex meta.embedded.html source.elixir.embedded.html -->
+<!-- ^^ text.html.eex meta.embedded.html - source -->
+<!--             ^^ punctuation.section.embedded.end.html -->
 <!--         ^^^ variable.other.elixir -->
 <!--    ^^^^ variable.function.elixir -->
-<!-- ^^ punctuation.section.embedded.begin.eex -->
+<!-- ^^ punctuation.section.embedded.begin.html -->
 
      <%= if true? do %>
-<!--                 ^^ text.html.eex meta.embedded.eex - source -->
-<!--    ^^^^^^^^^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.eex -->
-<!-- ^^^ text.html.eex meta.embedded.eex - source -->
-<!--                 ^^ punctuation.section.embedded.end.eex -->
+<!--                 ^^ text.html.eex meta.embedded.html - source -->
+<!--    ^^^^^^^^^^^^^ text.html.eex meta.embedded.html source.elixir.embedded.html -->
+<!-- ^^^ text.html.eex meta.embedded.html - source -->
+<!--                 ^^ punctuation.section.embedded.end.html -->
 <!--              ^^ keyword.context.block.do.elixir -->
 <!--        ^^^^^ variable.other.elixir -->
 <!--     ^^ keyword.control.conditional.elixir -->
-<!-- ^^^ punctuation.section.embedded.begin.eex -->
+<!-- ^^^ punctuation.section.embedded.begin.html -->
      <% end %>
-<!--        ^^ text.html.eex meta.embedded.eex - source -->
-<!--   ^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.eex -->
-<!-- ^^ text.html.eex meta.embedded.eex - source -->
-<!--        ^^ punctuation.section.embedded.end.eex -->
+<!--        ^^ text.html.eex meta.embedded.html - source -->
+<!--   ^^^^^ text.html.eex meta.embedded.html source.elixir.embedded.html -->
+<!-- ^^ text.html.eex meta.embedded.html - source -->
+<!--        ^^ punctuation.section.embedded.end.html -->
 <!--    ^^^ keyword.context.block.end.elixir -->
-<!-- ^^ punctuation.section.embedded.begin.eex -->
+<!-- ^^ punctuation.section.embedded.begin.html -->
 
      <%% quoted :code %>
-<!--                  ^^ text.html.eex meta.embedded.eex - source -->
-<!--    ^^^^^^^^^^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.eex -->
-<!-- ^^^ text.html.eex meta.embedded.eex - source -->
-<!--                  ^^ punctuation.section.embedded.end.eex -->
+<!--                  ^^ text.html.eex meta.embedded.html - source -->
+<!--    ^^^^^^^^^^^^^^ text.html.eex meta.embedded.html source.elixir.embedded.html -->
+<!-- ^^^ text.html.eex meta.embedded.html - source -->
+<!--                  ^^ punctuation.section.embedded.end.html -->
 <!--            ^^^^^ constant.other.symbol.elixir -->
 <!--     ^^^^^^ variable.function.elixir -->
-<!-- ^^^ punctuation.section.embedded.begin.eex -->
+<!-- ^^^ punctuation.section.embedded.begin.html -->
 
      <%%= quoted :result %>
-<!--                     ^^ text.html.eex meta.embedded.eex - source -->
-<!--     ^^^^^^^^^^^^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.eex -->
-<!-- ^^^^ text.html.eex meta.embedded.eex - source -->
-<!--                     ^^ punctuation.section.embedded.end.eex -->
+<!--                     ^^ text.html.eex meta.embedded.html - source -->
+<!--     ^^^^^^^^^^^^^^^^ text.html.eex meta.embedded.html source.elixir.embedded.html -->
+<!-- ^^^^ text.html.eex meta.embedded.html - source -->
+<!--                     ^^ punctuation.section.embedded.end.html -->
 <!--             ^^^^^^^ constant.other.symbol.elixir -->
 <!--      ^^^^^^ variable.function.elixir -->
-<!-- ^^^^ punctuation.section.embedded.begin.eex -->
+<!-- ^^^^ punctuation.section.embedded.begin.html -->
 </html>

--- a/tests/syntax_test_template.html.eex
+++ b/tests/syntax_test_template.html.eex
@@ -3,56 +3,72 @@
    <!DOCTYPE html>
 <!-- ^^^^^^^ keyword.declaration.doctype.html -->
 <html lang="<%= "en" %>">
+<!--                   ^ meta.attribute-with-value.html meta.string.html - meta.interpolation -->
+<!--                 ^^ meta.attribute-with-value.html meta.string.html meta.embedded.eex - source -->
+<!--           ^^^^^^ meta.attribute-with-value.html meta.string.html meta.embedded.eex source.elixir.embedded.html -->
+<!--        ^^^ meta.attribute-with-value.html meta.string.html meta.embedded.eex - source -->
+<!--       ^ meta.attribute-with-value.html meta.string.html - meta.interpolation -->
 <!--                   ^ punctuation.definition.string.end.html -->
-<!--                  ^ punctuation.section.embedded.end.eex -->
-<!--            ^^^^ string.quoted.double.elixir -->
-<!--         ^^ entity.name.tag.eex -->
-<!--        ^ punctuation.section.embedded.begin.eex -->
+<!--                 ^^ punctuation.section.embedded.end.eex -->
+<!--            ^^^^ string.quoted.double.elixir - string string -->
+<!--        ^^^ punctuation.section.embedded.begin.eex -->
 <!--       ^ punctuation.definition.string.begin.html -->
 
      <%# Comment %>
-<!--             ^^ punctuation.definition.comment.end.eex -->
-<!--     ^^^^^^^ -constant -->
-<!-- ^^^^^^^^^^^^^^ text.html.eex comment.block.eex -->
-<!-- ^^^ punctuation.definition.comment.begin.eex -->
+<!--             ^^ punctuation.section.embedded.end.eex - comment -->
+<!--   ^^^^^^^^^^ comment.block.eex - constant -->
+<!--   ^ punctuation.definition.comment.begin.eex -->
+<!-- ^^ punctuation.section.embedded.begin.eex - comment -->
+<!-- ^^^^^^^^^^^^^^ text.html.eex meta.embedded.eex -->
+
+     <br class="<%# Comment %>" />
+<!--                        ^^ punctuation.section.embedded.end.eex - comment -->
+<!--              ^^^^^^^^^^ comment.block.eex - constant -->
+<!--              ^ punctuation.definition.comment.begin.eex -->
+<!--            ^^ punctuation.section.embedded.begin.eex - comment -->
+<!--            ^^^^^^^^^^^^^^ text.html.eex meta.embedded.eex - string -->
 
      <% func arg %>
-<!--              ^ punctuation.section.embedded.end.eex -->
-<!--             ^ entity.name.tag.eex -->
+<!--             ^^ text.html.eex meta.embedded.eex - source -->
+<!--   ^^^^^^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.html -->
+<!-- ^^ text.html.eex meta.embedded.eex - source -->
+<!--             ^^ punctuation.section.embedded.end.eex -->
 <!--         ^^^ variable.other.elixir -->
 <!--    ^^^^ variable.function.elixir -->
-<!--  ^ entity.name.tag.eex -->
-<!-- ^ punctuation.section.embedded.begin.eex -->
-<!-- ^^^^^^^^^^^^^^ meta.interpolation.eex text.html.eex -->
+<!-- ^^ punctuation.section.embedded.begin.eex -->
 
      <%= if true? do %>
-<!--                  ^ punctuation.section.embedded.end.eex -->
-<!--                 ^ entity.name.tag.eex -->
+<!--                 ^^ text.html.eex meta.embedded.eex - source -->
+<!--    ^^^^^^^^^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.html -->
+<!-- ^^^ text.html.eex meta.embedded.eex - source -->
+<!--                 ^^ punctuation.section.embedded.end.eex -->
 <!--              ^^ keyword.context.block.do.elixir -->
 <!--        ^^^^^ variable.other.elixir -->
 <!--     ^^ keyword.control.conditional.elixir -->
-<!--  ^^ entity.name.tag.eex -->
-<!-- ^ punctuation.section.embedded.begin.eex -->
+<!-- ^^^ punctuation.section.embedded.begin.eex -->
      <% end %>
-<!--         ^ punctuation.section.embedded.end.eex -->
-<!--        ^ entity.name.tag.eex -->
+<!--        ^^ text.html.eex meta.embedded.eex - source -->
+<!--   ^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.html -->
+<!-- ^^ text.html.eex meta.embedded.eex - source -->
+<!--        ^^ punctuation.section.embedded.end.eex -->
 <!--    ^^^ keyword.context.block.end.elixir -->
-<!--  ^ entity.name.tag.eex -->
-<!-- ^ punctuation.section.embedded.begin.eex -->
+<!-- ^^ punctuation.section.embedded.begin.eex -->
 
      <%% quoted :code %>
-<!--                   ^ punctuation.section.embedded.end.eex -->
-<!--                  ^ entity.name.tag.eex -->
+<!--                  ^^ text.html.eex meta.embedded.eex - source -->
+<!--    ^^^^^^^^^^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.html -->
+<!-- ^^^ text.html.eex meta.embedded.eex - source -->
+<!--                  ^^ punctuation.section.embedded.end.eex -->
 <!--            ^^^^^ constant.other.symbol.elixir -->
 <!--     ^^^^^^ variable.function.elixir -->
-<!--  ^^ entity.name.tag.eex -->
-<!-- ^ punctuation.section.embedded.begin.eex -->
+<!-- ^^^ punctuation.section.embedded.begin.eex -->
 
      <%%= quoted :result %>
-<!--                      ^ punctuation.section.embedded.end.eex -->
-<!--                     ^ entity.name.tag.eex -->
+<!--                     ^^ text.html.eex meta.embedded.eex - source -->
+<!--     ^^^^^^^^^^^^^^^^ text.html.eex meta.embedded.eex source.elixir.embedded.html -->
+<!-- ^^^^ text.html.eex meta.embedded.eex - source -->
+<!--                     ^^ punctuation.section.embedded.end.eex -->
 <!--             ^^^^^^^ constant.other.symbol.elixir -->
 <!--      ^^^^^^ variable.function.elixir -->
-<!--  ^^^ entity.name.tag.eex -->
-<!-- ^ punctuation.section.embedded.begin.eex -->
+<!-- ^^^^ punctuation.section.embedded.begin.eex -->
 </html>

--- a/tests/syntax_test_template.html.heex
+++ b/tests/syntax_test_template.html.heex
@@ -24,11 +24,11 @@
 <!--                   ^^^^^^^^^^^^ comment.block.html meta.embedded.html -->
 
      <%# Comment %>
-<!--             ^^ punctuation.section.embedded.end.eex - comment -->
+<!--             ^^ punctuation.section.embedded.end.html - comment -->
 <!--   ^^^^^^^^^^ comment.block.eex - constant -->
 <!--   ^ punctuation.definition.comment.begin.eex -->
-<!-- ^^ punctuation.section.embedded.begin.eex - comment -->
-<!-- ^^^^^^^^^^^^^^ text.html.heex meta.embedded.eex -->
+<!-- ^^ punctuation.section.embedded.begin.html - comment -->
+<!-- ^^^^^^^^^^^^^^ text.html.heex meta.embedded.html -->
 
      <script>
        <%= @elixir %>
@@ -99,46 +99,46 @@
 <!-- ^^^^^^^^^^ - meta.tag -->
 
      <% func arg %>
-<!--             ^^ text.html.heex meta.embedded.eex - source -->
-<!--   ^^^^^^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.eex -->
-<!-- ^^ text.html.heex meta.embedded.eex - source -->
-<!--             ^^ punctuation.section.embedded.end.eex -->
+<!--             ^^ text.html.heex meta.embedded.html - source -->
+<!--   ^^^^^^^^^^ text.html.heex meta.embedded.html source.elixir.embedded.html -->
+<!-- ^^ text.html.heex meta.embedded.html - source -->
+<!--             ^^ punctuation.section.embedded.end.html -->
 <!--         ^^^ variable.other.elixir -->
 <!--    ^^^^ variable.function.elixir -->
-<!-- ^^ punctuation.section.embedded.begin.eex -->
+<!-- ^^ punctuation.section.embedded.begin.html -->
 
      <%= if true? do %>
-<!--                 ^^ text.html.heex meta.embedded.eex - source -->
-<!--    ^^^^^^^^^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.eex -->
-<!-- ^^^ text.html.heex meta.embedded.eex - source -->
-<!--                 ^^ punctuation.section.embedded.end.eex -->
+<!--                 ^^ text.html.heex meta.embedded.html - source -->
+<!--    ^^^^^^^^^^^^^ text.html.heex meta.embedded.html source.elixir.embedded.html -->
+<!-- ^^^ text.html.heex meta.embedded.html - source -->
+<!--                 ^^ punctuation.section.embedded.end.html -->
 <!--              ^^ keyword.context.block.do.elixir -->
 <!--        ^^^^^ variable.other.elixir -->
 <!--     ^^ keyword.control.conditional.elixir -->
-<!-- ^^^ punctuation.section.embedded.begin.eex -->
+<!-- ^^^ punctuation.section.embedded.begin.html -->
      <% end %>
-<!--        ^^ text.html.heex meta.embedded.eex - source -->
-<!--   ^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.eex -->
-<!-- ^^ text.html.heex meta.embedded.eex - source -->
-<!--        ^^ punctuation.section.embedded.end.eex -->
+<!--        ^^ text.html.heex meta.embedded.html - source -->
+<!--   ^^^^^ text.html.heex meta.embedded.html source.elixir.embedded.html -->
+<!-- ^^ text.html.heex meta.embedded.html - source -->
+<!--        ^^ punctuation.section.embedded.end.html -->
 <!--    ^^^ keyword.context.block.end.elixir -->
-<!-- ^^ punctuation.section.embedded.begin.eex -->
+<!-- ^^ punctuation.section.embedded.begin.html -->
 
      <%% quoted :code %>
-<!--                  ^^ text.html.heex meta.embedded.eex - source -->
-<!--    ^^^^^^^^^^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.eex -->
-<!-- ^^^ text.html.heex meta.embedded.eex - source -->
-<!--                  ^^ punctuation.section.embedded.end.eex -->
+<!--                  ^^ text.html.heex meta.embedded.html - source -->
+<!--    ^^^^^^^^^^^^^^ text.html.heex meta.embedded.html source.elixir.embedded.html -->
+<!-- ^^^ text.html.heex meta.embedded.html - source -->
+<!--                  ^^ punctuation.section.embedded.end.html -->
 <!--            ^^^^^ constant.other.symbol.elixir -->
 <!--     ^^^^^^ variable.function.elixir -->
-<!-- ^^^ punctuation.section.embedded.begin.eex -->
+<!-- ^^^ punctuation.section.embedded.begin.html -->
 
      <%%= quoted :result %>
-<!--                     ^^ text.html.heex meta.embedded.eex - source -->
-<!--     ^^^^^^^^^^^^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.eex -->
-<!-- ^^^^ text.html.heex meta.embedded.eex - source -->
-<!--                     ^^ punctuation.section.embedded.end.eex -->
+<!--                     ^^ text.html.heex meta.embedded.html - source -->
+<!--     ^^^^^^^^^^^^^^^^ text.html.heex meta.embedded.html source.elixir.embedded.html -->
+<!-- ^^^^ text.html.heex meta.embedded.html - source -->
+<!--                     ^^ punctuation.section.embedded.end.html -->
 <!--             ^^^^^^^ constant.other.symbol.elixir -->
 <!--      ^^^^^^ variable.function.elixir -->
-<!-- ^^^^ punctuation.section.embedded.begin.eex -->
+<!-- ^^^^ punctuation.section.embedded.begin.html -->
 </html>

--- a/tests/syntax_test_template.html.heex
+++ b/tests/syntax_test_template.html.heex
@@ -2,6 +2,7 @@
 
    <!DOCTYPE html>
 <!-- ^^^^^^^ keyword.declaration.doctype.html -->
+
 <html lang="{"en"}" lang={"en"}>
 <!--                           ^ punctuation.definition.tag.end.html -->
 <!--             ^ punctuation.section.interpolation.end.elixir -->
@@ -9,11 +10,36 @@
 <!--        ^ punctuation.section.interpolation.begin.elixir -->
 <!--       ^ punctuation.definition.string.begin.html -->
 
+<!-- HTML comment with {"interpolation"} ?? -->
+<!--                                   ^ punctuation.section.interpolation.end.elixir - source -->
+<!--                    ^^^^^^^^^^^^^^^ source.elixir.interpolated.html -->
+<!--                   ^ punctuation.section.interpolation.begin.elixir - source -->
+<!--                   ^^^^^^^^^^^^^^^^^ comment.block.html meta.interpolation.html -->
+
      <%# Comment %>
-<!--             ^^ punctuation.definition.comment.end.eex -->
-<!--     ^^^^^^^ -constant -->
-<!-- ^^^^^^^^^^^^^^ text.html.eex comment.block.eex -->
-<!-- ^^^ punctuation.definition.comment.begin.eex -->
+<!--             ^^ punctuation.section.embedded.end.eex - comment -->
+<!--   ^^^^^^^^^^ comment.block.eex - constant -->
+<!--   ^ punctuation.definition.comment.begin.eex -->
+<!-- ^^ punctuation.section.embedded.begin.eex - comment -->
+<!-- ^^^^^^^^^^^^^^ text.html.heex meta.embedded.eex -->
+
+     <br class="<%# Comment %>" />
+<!--           ^^^^^^^^^^^^^^^^ meta.string.html string.quoted.double.html - comment -->
+
+     <p {"tag"}={"value"} >
+<!--                      ^ punctuation.definition.tag.end.html -->
+<!--                    ^ punctuation.section.interpolation.end.elixir - source -->
+<!--             ^^^^^^^ source.elixir.interpolated.html meta.string.elixir string.quoted.double.elixir -->
+<!--            ^ punctuation.section.interpolation.begin.elixir - source -->
+<!--           ^ punctuation.separator.key-value.html -->
+<!--          ^ punctuation.section.interpolation.end.elixir - string -->
+<!--     ^^^^^ source.elixir.interpolated.html meta.string.elixir string.quoted.double.elixir -->
+<!--    ^ punctuation.section.interpolation.begin.elixir - source -->
+<!--                     ^^ meta.tag.block.any.html - meta.attribute-with-value -->
+<!--            ^^^^^^^^^ meta.tag meta.attribute-with-value.html meta.string.html meta.interpolation.html -->
+<!--           ^ meta.tag meta.attribute-with-value.html - meta.interpolation -->
+<!--    ^^^^^^^ meta.tag meta.attribute-with-value.html meta.interpolation.html -->
+<!-- ^^^ meta.tag.block.any.html - meta.attribute-with-value -->
 
      <.form>
 <!--   ^^^^ text.html.heex variable.function.heex -->
@@ -22,58 +48,87 @@
 <!--    ^^^^ variable.function.heex -->
 <!--   ^ punctuation.accessor.dot.heex -->
 
+     <MyApp name={@name}>
+<!--        ^^^^^^^^^^^^ meta.attribute-with-value.html -->
+<!--       ^ - entity -->
+<!--  ^^^^^ entity.name.tag.begin.heex -->
+<!-- ^ punctuation.definition.tag.begin.html -->
+<!-- ^^^^^^^^^^^^^^^^^^^^ meta.tag.other.heex - meta.tag meta.tag -->
+
      <MyApp.User.tag name={@name}>
-<!--                      ^^^^^^^ source.elixir.interpolated.html -->
+<!--                      ^^^^^^^ meta.attribute-with-value.html meta.string.html meta.interpolation.html -->
+<!--                 ^^^^^ meta.attribute-with-value.html - meta.interpolation -->
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.heex - meta.tag meta.tag -->
+<!--                             ^ punctuation.definition.tag.end.html -->
+<!--                            ^ punctuation.section.interpolation.end.elixir -->
+<!--                       ^^^^^ source.elixir.interpolated.html -->
+<!--                      ^ punctuation.section.interpolation.begin.elixir -->
+<!--                     ^ punctuation.separator.key-value.html -->
 <!--                 ^^^^ entity.other.attribute-name.html -->
 <!--             ^^^ variable.function.heex -->
 <!--            ^ punctuation.accessor.dot.heex -->
 <!--        ^^^^ entity.name.tag.begin.heex -->
 <!--       ^ punctuation.accessor.dot.heex -->
 <!--  ^^^^^ entity.name.tag.begin.heex -->
+<!-- ^ punctuation.definition.tag.begin.html -->
      </MyApp.User.tag>
+<!--                 ^ punctuation.definition.tag.end.html -->
 <!--              ^^^ variable.function.heex -->
 <!--             ^ punctuation.accessor.dot.heex -->
 <!--         ^^^^ entity.name.tag.end.heex -->
 <!--        ^ punctuation.accessor.dot.heex -->
 <!--   ^^^^^ entity.name.tag.end.heex -->
+<!-- ^ punctuation.definition.tag.begin.html -->
+<!-- ^^^^^^^^^^^^^^^^^ meta.tag.other.heex - meta.tag meta.tag -->
+
+     <t{=@a}a />
+<!--  ^^^^^^^ entity.name.tag.other.html - meta.interpolation - source -->
+<!-- ^^^^^^^^^^^ meta.tag.other.html -->
+
+     <{=@a}a />
+<!-- ^^^^^^^^^^ - meta.tag -->
 
      <% func arg %>
-<!--              ^ punctuation.section.embedded.end.eex -->
-<!--             ^ entity.name.tag.eex -->
+<!--             ^^ text.html.heex meta.embedded.eex - source -->
+<!--   ^^^^^^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.html -->
+<!-- ^^ text.html.heex meta.embedded.eex - source -->
+<!--             ^^ punctuation.section.embedded.end.eex -->
 <!--         ^^^ variable.other.elixir -->
 <!--    ^^^^ variable.function.elixir -->
-<!--  ^ entity.name.tag.eex -->
-<!-- ^ punctuation.section.embedded.begin.eex -->
-<!-- ^^^^^^^^^^^^^^ meta.interpolation.eex text.html.eex -->
+<!-- ^^ punctuation.section.embedded.begin.eex -->
 
      <%= if true? do %>
-<!--                  ^ punctuation.section.embedded.end.eex -->
-<!--                 ^ entity.name.tag.eex -->
+<!--                 ^^ text.html.heex meta.embedded.eex - source -->
+<!--    ^^^^^^^^^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.html -->
+<!-- ^^^ text.html.heex meta.embedded.eex - source -->
+<!--                 ^^ punctuation.section.embedded.end.eex -->
 <!--              ^^ keyword.context.block.do.elixir -->
 <!--        ^^^^^ variable.other.elixir -->
 <!--     ^^ keyword.control.conditional.elixir -->
-<!--  ^^ entity.name.tag.eex -->
-<!-- ^ punctuation.section.embedded.begin.eex -->
+<!-- ^^^ punctuation.section.embedded.begin.eex -->
      <% end %>
-<!--         ^ punctuation.section.embedded.end.eex -->
-<!--        ^ entity.name.tag.eex -->
+<!--        ^^ text.html.heex meta.embedded.eex - source -->
+<!--   ^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.html -->
+<!-- ^^ text.html.heex meta.embedded.eex - source -->
+<!--        ^^ punctuation.section.embedded.end.eex -->
 <!--    ^^^ keyword.context.block.end.elixir -->
-<!--  ^ entity.name.tag.eex -->
-<!-- ^ punctuation.section.embedded.begin.eex -->
+<!-- ^^ punctuation.section.embedded.begin.eex -->
 
      <%% quoted :code %>
-<!--                   ^ punctuation.section.embedded.end.eex -->
-<!--                  ^ entity.name.tag.eex -->
+<!--                  ^^ text.html.heex meta.embedded.eex - source -->
+<!--    ^^^^^^^^^^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.html -->
+<!-- ^^^ text.html.heex meta.embedded.eex - source -->
+<!--                  ^^ punctuation.section.embedded.end.eex -->
 <!--            ^^^^^ constant.other.symbol.elixir -->
 <!--     ^^^^^^ variable.function.elixir -->
-<!--  ^^ entity.name.tag.eex -->
-<!-- ^ punctuation.section.embedded.begin.eex -->
+<!-- ^^^ punctuation.section.embedded.begin.eex -->
 
      <%%= quoted :result %>
-<!--                      ^ punctuation.section.embedded.end.eex -->
-<!--                     ^ entity.name.tag.eex -->
+<!--                     ^^ text.html.heex meta.embedded.eex - source -->
+<!--     ^^^^^^^^^^^^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.html -->
+<!-- ^^^^ text.html.heex meta.embedded.eex - source -->
+<!--                     ^^ punctuation.section.embedded.end.eex -->
 <!--             ^^^^^^^ constant.other.symbol.elixir -->
 <!--      ^^^^^^ variable.function.elixir -->
-<!--  ^^^ entity.name.tag.eex -->
-<!-- ^ punctuation.section.embedded.begin.eex -->
+<!-- ^^^^ punctuation.section.embedded.begin.eex -->
 </html>

--- a/tests/syntax_test_template.html.heex
+++ b/tests/syntax_test_template.html.heex
@@ -5,9 +5,16 @@
 
 <html lang="{"en"}" lang={"en"}>
 <!--                           ^ punctuation.definition.tag.end.html -->
-<!--             ^ punctuation.section.embedded.end.heex -->
-<!--         ^^^^ string.quoted.double.elixir -->
-<!--        ^ punctuation.section.embedded.begin.heex -->
+<!--                          ^ punctuation.section.embedded.end.heex -->
+<!--                     ^^^^^^ meta.attribute-with-value.html meta.embedded.heex -->
+<!--                     ^ punctuation.section.embedded.begin.heex -->
+<!--                    ^ punctuation.separator.key-value.html -->
+<!--                ^^^^ entity.other.attribute-name.html -->
+<!--                ^^^^^ meta.attribute-with-value.html - meta.embedded -->
+<!--              ^ invalid.illegal.attribute-name.html -->
+<!--            ^ invalid.illegal.attribute-name.html -->
+<!--          ^^^^^ entity.other.attribute-name.html -->
+<!--       ^^^ meta.string.html string.quoted.double.html -->
 <!--       ^ punctuation.definition.string.begin.html -->
 
 <!-- HTML comment with {"embedded"} ?? -->
@@ -37,13 +44,11 @@
 <!--             ^^^^^^^ source.elixir.embedded.heex meta.string.elixir string.quoted.double.elixir -->
 <!--            ^ punctuation.section.embedded.begin.heex - source -->
 <!--           ^ punctuation.separator.key-value.html -->
-<!--          ^ punctuation.section.embedded.end.heex - string -->
-<!--     ^^^^^ source.elixir.embedded.heex meta.string.elixir string.quoted.double.elixir -->
-<!--    ^ punctuation.section.embedded.begin.heex - source -->
+<!--    ^^^^^^^ entity.other.attribute-name.html -->
 <!--                     ^^ meta.tag.block.any.html - meta.attribute-with-value -->
-<!--            ^^^^^^^^^ meta.tag meta.attribute-with-value.html meta.string.html meta.embedded.heex -->
+<!--            ^^^^^^^^^ meta.tag meta.attribute-with-value.html meta.embedded.heex -->
 <!--           ^ meta.tag meta.attribute-with-value.html - meta.embedded -->
-<!--    ^^^^^^^ meta.tag meta.attribute-with-value.html meta.embedded.heex -->
+<!--    ^^^^^^^ meta.tag meta.attribute-with-value.html - meta.embedded -->
 <!-- ^^^ meta.tag.block.any.html - meta.attribute-with-value -->
 
      <.form>
@@ -61,7 +66,7 @@
 <!-- ^^^^^^^^^^^^^^^^^^^^ meta.tag.other.heex - meta.tag meta.tag -->
 
      <MyApp.User.tag name={@name}>
-<!--                      ^^^^^^^ meta.attribute-with-value.html meta.string.html meta.embedded.heex -->
+<!--                      ^^^^^^^ meta.attribute-with-value.html meta.embedded.heex -->
 <!--                 ^^^^^ meta.attribute-with-value.html - meta.embedded -->
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.heex - meta.tag meta.tag -->
 <!--                             ^ punctuation.definition.tag.end.html -->

--- a/tests/syntax_test_template.html.heex
+++ b/tests/syntax_test_template.html.heex
@@ -5,16 +5,16 @@
 
 <html lang="{"en"}" lang={"en"}>
 <!--                           ^ punctuation.definition.tag.end.html -->
-<!--             ^ punctuation.section.interpolation.end.elixir -->
+<!--             ^ punctuation.section.embedded.end.heex -->
 <!--         ^^^^ string.quoted.double.elixir -->
-<!--        ^ punctuation.section.interpolation.begin.elixir -->
+<!--        ^ punctuation.section.embedded.begin.heex -->
 <!--       ^ punctuation.definition.string.begin.html -->
 
-<!-- HTML comment with {"interpolation"} ?? -->
-<!--                                   ^ punctuation.section.interpolation.end.elixir - source -->
-<!--                    ^^^^^^^^^^^^^^^ source.elixir.interpolated.html -->
-<!--                   ^ punctuation.section.interpolation.begin.elixir - source -->
-<!--                   ^^^^^^^^^^^^^^^^^ comment.block.html meta.interpolation.html -->
+<!-- HTML comment with {"embedded"} ?? -->
+<!--                              ^ punctuation.section.embedded.end.heex - source -->
+<!--                    ^^^^^^^^^^ source.elixir.embedded.heex -->
+<!--                   ^ punctuation.section.embedded.begin.heex - source -->
+<!--                   ^^^^^^^^^^^^ comment.block.html meta.embedded.heex -->
 
      <%# Comment %>
 <!--             ^^ punctuation.section.embedded.end.eex - comment -->
@@ -28,17 +28,17 @@
 
      <p {"tag"}={"value"} >
 <!--                      ^ punctuation.definition.tag.end.html -->
-<!--                    ^ punctuation.section.interpolation.end.elixir - source -->
-<!--             ^^^^^^^ source.elixir.interpolated.html meta.string.elixir string.quoted.double.elixir -->
-<!--            ^ punctuation.section.interpolation.begin.elixir - source -->
+<!--                    ^ punctuation.section.embedded.end.heex - source -->
+<!--             ^^^^^^^ source.elixir.embedded.heex meta.string.elixir string.quoted.double.elixir -->
+<!--            ^ punctuation.section.embedded.begin.heex - source -->
 <!--           ^ punctuation.separator.key-value.html -->
-<!--          ^ punctuation.section.interpolation.end.elixir - string -->
-<!--     ^^^^^ source.elixir.interpolated.html meta.string.elixir string.quoted.double.elixir -->
-<!--    ^ punctuation.section.interpolation.begin.elixir - source -->
+<!--          ^ punctuation.section.embedded.end.heex - string -->
+<!--     ^^^^^ source.elixir.embedded.heex meta.string.elixir string.quoted.double.elixir -->
+<!--    ^ punctuation.section.embedded.begin.heex - source -->
 <!--                     ^^ meta.tag.block.any.html - meta.attribute-with-value -->
-<!--            ^^^^^^^^^ meta.tag meta.attribute-with-value.html meta.string.html meta.interpolation.html -->
-<!--           ^ meta.tag meta.attribute-with-value.html - meta.interpolation -->
-<!--    ^^^^^^^ meta.tag meta.attribute-with-value.html meta.interpolation.html -->
+<!--            ^^^^^^^^^ meta.tag meta.attribute-with-value.html meta.string.html meta.embedded.heex -->
+<!--           ^ meta.tag meta.attribute-with-value.html - meta.embedded -->
+<!--    ^^^^^^^ meta.tag meta.attribute-with-value.html meta.embedded.heex -->
 <!-- ^^^ meta.tag.block.any.html - meta.attribute-with-value -->
 
      <.form>
@@ -56,13 +56,13 @@
 <!-- ^^^^^^^^^^^^^^^^^^^^ meta.tag.other.heex - meta.tag meta.tag -->
 
      <MyApp.User.tag name={@name}>
-<!--                      ^^^^^^^ meta.attribute-with-value.html meta.string.html meta.interpolation.html -->
-<!--                 ^^^^^ meta.attribute-with-value.html - meta.interpolation -->
+<!--                      ^^^^^^^ meta.attribute-with-value.html meta.string.html meta.embedded.heex -->
+<!--                 ^^^^^ meta.attribute-with-value.html - meta.embedded -->
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.heex - meta.tag meta.tag -->
 <!--                             ^ punctuation.definition.tag.end.html -->
-<!--                            ^ punctuation.section.interpolation.end.elixir -->
-<!--                       ^^^^^ source.elixir.interpolated.html -->
-<!--                      ^ punctuation.section.interpolation.begin.elixir -->
+<!--                            ^ punctuation.section.embedded.end.heex -->
+<!--                       ^^^^^ source.elixir.embedded.heex -->
+<!--                      ^ punctuation.section.embedded.begin.heex -->
 <!--                     ^ punctuation.separator.key-value.html -->
 <!--                 ^^^^ entity.other.attribute-name.html -->
 <!--             ^^^ variable.function.heex -->
@@ -82,7 +82,7 @@
 <!-- ^^^^^^^^^^^^^^^^^ meta.tag.other.heex - meta.tag meta.tag -->
 
      <t{=@a}a />
-<!--  ^^^^^^^ entity.name.tag.other.html - meta.interpolation - source -->
+<!--  ^^^^^^^ entity.name.tag.other.html - meta.embedded - source -->
 <!-- ^^^^^^^^^^^ meta.tag.other.html -->
 
      <{=@a}a />
@@ -90,7 +90,7 @@
 
      <% func arg %>
 <!--             ^^ text.html.heex meta.embedded.eex - source -->
-<!--   ^^^^^^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.html -->
+<!--   ^^^^^^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.eex -->
 <!-- ^^ text.html.heex meta.embedded.eex - source -->
 <!--             ^^ punctuation.section.embedded.end.eex -->
 <!--         ^^^ variable.other.elixir -->
@@ -99,7 +99,7 @@
 
      <%= if true? do %>
 <!--                 ^^ text.html.heex meta.embedded.eex - source -->
-<!--    ^^^^^^^^^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.html -->
+<!--    ^^^^^^^^^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.eex -->
 <!-- ^^^ text.html.heex meta.embedded.eex - source -->
 <!--                 ^^ punctuation.section.embedded.end.eex -->
 <!--              ^^ keyword.context.block.do.elixir -->
@@ -108,7 +108,7 @@
 <!-- ^^^ punctuation.section.embedded.begin.eex -->
      <% end %>
 <!--        ^^ text.html.heex meta.embedded.eex - source -->
-<!--   ^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.html -->
+<!--   ^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.eex -->
 <!-- ^^ text.html.heex meta.embedded.eex - source -->
 <!--        ^^ punctuation.section.embedded.end.eex -->
 <!--    ^^^ keyword.context.block.end.elixir -->
@@ -116,7 +116,7 @@
 
      <%% quoted :code %>
 <!--                  ^^ text.html.heex meta.embedded.eex - source -->
-<!--    ^^^^^^^^^^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.html -->
+<!--    ^^^^^^^^^^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.eex -->
 <!-- ^^^ text.html.heex meta.embedded.eex - source -->
 <!--                  ^^ punctuation.section.embedded.end.eex -->
 <!--            ^^^^^ constant.other.symbol.elixir -->
@@ -125,7 +125,7 @@
 
      <%%= quoted :result %>
 <!--                     ^^ text.html.heex meta.embedded.eex - source -->
-<!--     ^^^^^^^^^^^^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.html -->
+<!--     ^^^^^^^^^^^^^^^^ text.html.heex meta.embedded.eex source.elixir.embedded.eex -->
 <!-- ^^^^ text.html.heex meta.embedded.eex - source -->
 <!--                     ^^ punctuation.section.embedded.end.eex -->
 <!--             ^^^^^^^ constant.other.symbol.elixir -->

--- a/tests/syntax_test_template.html.heex
+++ b/tests/syntax_test_template.html.heex
@@ -5,9 +5,9 @@
 
 <html lang="{"en"}" lang={"en"}>
 <!--                           ^ punctuation.definition.tag.end.html -->
-<!--                          ^ punctuation.section.embedded.end.heex -->
-<!--                     ^^^^^^ meta.attribute-with-value.html meta.embedded.heex -->
-<!--                     ^ punctuation.section.embedded.begin.heex -->
+<!--                          ^ punctuation.section.embedded.end.html -->
+<!--                     ^^^^^^ meta.attribute-with-value.html meta.embedded.html -->
+<!--                     ^ punctuation.section.embedded.begin.html -->
 <!--                    ^ punctuation.separator.key-value.html -->
 <!--                ^^^^ entity.other.attribute-name.html -->
 <!--                ^^^^^ meta.attribute-with-value.html - meta.embedded -->
@@ -18,10 +18,10 @@
 <!--       ^ punctuation.definition.string.begin.html -->
 
 <!-- HTML comment with {"embedded"} ?? -->
-<!--                              ^ punctuation.section.embedded.end.heex - source -->
-<!--                    ^^^^^^^^^^ source.elixir.embedded.heex -->
-<!--                   ^ punctuation.section.embedded.begin.heex - source -->
-<!--                   ^^^^^^^^^^^^ comment.block.html meta.embedded.heex -->
+<!--                              ^ punctuation.section.embedded.end.html - source -->
+<!--                    ^^^^^^^^^^ source.elixir.embedded.html -->
+<!--                   ^ punctuation.section.embedded.begin.html - source -->
+<!--                   ^^^^^^^^^^^^ comment.block.html meta.embedded.html -->
 
      <%# Comment %>
 <!--             ^^ punctuation.section.embedded.end.eex - comment -->
@@ -40,13 +40,13 @@
 
      <p {"tag"}={"value"} >
 <!--                      ^ punctuation.definition.tag.end.html -->
-<!--                    ^ punctuation.section.embedded.end.heex - source -->
-<!--             ^^^^^^^ source.elixir.embedded.heex meta.string.elixir string.quoted.double.elixir -->
-<!--            ^ punctuation.section.embedded.begin.heex - source -->
+<!--                    ^ punctuation.section.embedded.end.html - source -->
+<!--             ^^^^^^^ source.elixir.embedded.html meta.string.elixir string.quoted.double.elixir -->
+<!--            ^ punctuation.section.embedded.begin.html - source -->
 <!--           ^ punctuation.separator.key-value.html -->
 <!--    ^^^^^^^ entity.other.attribute-name.html -->
 <!--                     ^^ meta.tag.block.any.html - meta.attribute-with-value -->
-<!--            ^^^^^^^^^ meta.tag meta.attribute-with-value.html meta.embedded.heex -->
+<!--            ^^^^^^^^^ meta.tag meta.attribute-with-value.html meta.embedded.html -->
 <!--           ^ meta.tag meta.attribute-with-value.html - meta.embedded -->
 <!--    ^^^^^^^ meta.tag meta.attribute-with-value.html - meta.embedded -->
 <!-- ^^^ meta.tag.block.any.html - meta.attribute-with-value -->
@@ -66,13 +66,13 @@
 <!-- ^^^^^^^^^^^^^^^^^^^^ meta.tag.other.heex - meta.tag meta.tag -->
 
      <MyApp.User.tag name={@name}>
-<!--                      ^^^^^^^ meta.attribute-with-value.html meta.embedded.heex -->
+<!--                      ^^^^^^^ meta.attribute-with-value.html meta.embedded.html -->
 <!--                 ^^^^^ meta.attribute-with-value.html - meta.embedded -->
 <!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.heex - meta.tag meta.tag -->
 <!--                             ^ punctuation.definition.tag.end.html -->
-<!--                            ^ punctuation.section.embedded.end.heex -->
-<!--                       ^^^^^ source.elixir.embedded.heex -->
-<!--                      ^ punctuation.section.embedded.begin.heex -->
+<!--                            ^ punctuation.section.embedded.end.html -->
+<!--                       ^^^^^ source.elixir.embedded.html -->
+<!--                      ^ punctuation.section.embedded.begin.html -->
 <!--                     ^ punctuation.separator.key-value.html -->
 <!--                 ^^^^ entity.other.attribute-name.html -->
 <!--             ^^^ variable.function.heex -->

--- a/tests/syntax_test_template.html.heex
+++ b/tests/syntax_test_template.html.heex
@@ -51,12 +51,43 @@
 <!--    ^^^^^^^ meta.tag meta.attribute-with-value.html - meta.embedded -->
 <!-- ^^^ meta.tag.block.any.html - meta.attribute-with-value -->
 
-     <.form>
-<!--   ^^^^ text.html.heex variable.function.heex -->
+     <.table rows={@users}>
+<!--                      ^ punctuation.definition.tag.end.html -->
+<!--                     ^ punctuation.section.embedded.end.html -->
+<!--               ^^^^^^ source.elixir.embedded.html -->
+<!--              ^ punctuation.section.embedded.begin.html -->
+<!--             ^ punctuation.separator.key-value.html -->
+<!--         ^^^^ entity.other.attribute-name.html -->
+<!--   ^^^^^ variable.function.heex -->
 <!--  ^ punctuation.accessor.dot.heex -->
-     </.form>
-<!--    ^^^^ variable.function.heex -->
+<!-- ^ punctuation.definition.tag.begin.html -->
+<!--                      ^ meta.tag.other.heex - meta.attribute-with-value - meta.embedded -->
+<!--              ^^^^^^^^ meta.tag.other.heex meta.attribute-with-value.html meta.embedded.html -->
+<!--         ^^^^^ meta.tag.other.heex meta.attribute-with-value.html - meta.embedded -->
+<!-- ^^^^^^^^ meta.tag.other.heex - meta.attribute-with-value-->
+       <:col let={user} label="Name">
+<!--                                ^ punctuation.definition.tag.end.html -->
+<!--                    ^^^^^^^^^^^^ meta.attribute-with-value.html -->
+<!--         ^^^^^^^^^^ meta.attribute-with-value.html -->
+<!--    ^^^^ entity.name.tag.begin.heex - punctuation -->
+<!--   ^ punctuation.definition.tag.begin.html -->
+<!--   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.heex -->
+         <%= user.name %>
+<!--                   ^^ punctuation.section.embedded.end.html -->
+<!--        ^^^^^^^^^^^ source.elixir.embedded.html -->
+<!--     ^^^ punctuation.section.embedded.begin.html -->
+<!--     ^^^^^^^^^^^^^^^^ meta.embedded.html -->
+       </:col>
+<!--         ^ punctuation.definition.tag.end.html -->
+<!--     ^^^^ entity.name.tag.end.heex - punctuation -->
+<!--   ^^ punctuation.definition.tag.begin.html -->
+<!--   ^^^^^^^ meta.tag.other.heex -->
+     </.table>
+<!--         ^ punctuation.definition.tag.end.html -->
+<!--    ^^^^^ variable.function.heex -->
 <!--   ^ punctuation.accessor.dot.heex -->
+<!-- ^^ punctuation.definition.tag.begin.html -->
+<!-- ^^^^^^^^^ meta.tag.other.heex -->
 
      <MyApp name={@name}>
 <!--        ^^^^^^^^^^^^ meta.attribute-with-value.html -->

--- a/tests/syntax_test_template.html.heex
+++ b/tests/syntax_test_template.html.heex
@@ -23,6 +23,11 @@
 <!-- ^^ punctuation.section.embedded.begin.eex - comment -->
 <!-- ^^^^^^^^^^^^^^ text.html.heex meta.embedded.eex -->
 
+     <script>
+       <%= @elixir %>
+<!--        ^^^^^^ variable.annotation.js - source.elixir -->
+     </script>
+
      <br class="<%# Comment %>" />
 <!--           ^^^^^^^^^^^^^^^^ meta.string.html string.quoted.double.html - comment -->
 

--- a/tests/syntax_test_template.sface
+++ b/tests/syntax_test_template.sface
@@ -160,16 +160,17 @@
 # ^ punctuation.definition.tag.begin.html
 # ^^^^^^ meta.tag.other.surface - meta.attribute-with-value
   <#Raw>
-#      ^ -punctuation.definition.tag.end.html
-#  ^^^^ -entity.name.tag.begin.surface
-# ^ -punctuation.definition.tag.begin.html
+#      ^ - punctuation
+#  ^^^^ - entity
+# ^ - punctuation
     <:slot args={@args}></:slot>
-#                         ^^^^^ -entity.name
-#          ^^^^^^^^^^^^ -variable -entity -punctuation
-#    ^^^^^ -entity.name
-    <span style="{@style}" {=@prop}></span>
-#                                     ^^^^ entity.name.tag.inline.any.html
-#                ^^^^^^^^ -source.elixir.interpolated
+#                         ^^^^^ - entity
+#          ^^^^^^^^^^^^ - variable - entity - punctuation
+#    ^^^^^ - entity
+    <span style={@style} style="{@style}" {=@prop}></span>
+#                                                    ^^^^ entity.name.tag.inline.any.html
+#                               ^^^^^^^^ - source.elixir
+#               ^^^^^^^^ - source.elixir
 #    ^^^^ entity.name.tag.inline.any.html
   </#Raw>
 #       ^ punctuation.definition.tag.end.html
@@ -233,6 +234,10 @@
 #                                                 ^^^ punctuation.definition.comment.end.surface
 #^^^^ punctuation.definition.comment.begin.surface
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.html.surface meta.embedded.surface comment.block.surface - source - variable
+
+<tag{@a} />
+#   ^^^^ - source.elixir
+#^^^^^^^ entity.name.tag.begin.html
 
 <{}}>{@x}</{}}>
 #          ^^^ entity.name.tag.end.html

--- a/tests/syntax_test_template.sface
+++ b/tests/syntax_test_template.sface
@@ -2,10 +2,10 @@
 
 <html lang="{"en"}" lang={"en"}>
 #                              ^ punctuation.definition.tag.end.html
-#                             ^ punctuation.section.embedded.end.surface
-#                         ^^^^ source.elixir.embedded.surface meta.string.elixir string.quoted.double.elixir
-#                        ^^^^^^ meta.attribute-with-value.html meta.embedded.surface
-#                        ^ punctuation.section.embedded.begin.surface
+#                             ^ punctuation.section.embedded.end.html
+#                         ^^^^ source.elixir.embedded.html meta.string.elixir string.quoted.double.elixir
+#                        ^^^^^^ meta.attribute-with-value.html meta.embedded.html
+#                        ^ punctuation.section.embedded.begin.html
 #                       ^ punctuation.separator.key-value.html
 #                   ^^^^ entity.other.attribute-name.html
 #                 ^ invalid.illegal.attribute-name.html
@@ -16,10 +16,10 @@
 #          ^ punctuation.definition.string.begin.html
 
 <!-- HTML comment with {"embedded"} ?? -->
-#                                 ^ punctuation.section.embedded.end.surface - source
-#                       ^^^^^^^^^^ source.elixir.embedded.surface
-#                      ^ punctuation.section.embedded.begin.surface - source
-#                      ^^^^^^^^^^^^ comment.block.html meta.embedded.surface
+#                                 ^ punctuation.section.embedded.end.html - source
+#                       ^^^^^^^^^^ source.elixir.embedded.html
+#                      ^ punctuation.section.embedded.begin.html - source
+#                      ^^^^^^^^^^^^ comment.block.html meta.embedded.html
 
      <%# Comment %>
 #                 ^ punctuation.definition.tag.end.html
@@ -36,45 +36,45 @@
 #                                        ^^^^^^^^^^ string.quoted.double
 #                                       ^ punctuation.separator.key-value
 #                                     ^^ entity
-#                                   ^ meta.embedded.surface punctuation.section.embedded.end.surface - source
+#                                   ^ meta.embedded.html punctuation.section.embedded.end.html - source
 #                           ^^^^ constant.other.keyword
 #             ^^^^^^ constant.other.keyword
-#             ^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.surface source.elixir.embedded.surface
-#            ^ meta.embedded.surface punctuation.section.embedded.begin.surface - source
+#             ^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.html source.elixir.embedded.html
+#            ^ meta.embedded.html punctuation.section.embedded.begin.html - source
 #^^^^^^ entity.name.tag.begin.surface
   {#for i <- 1..max}
-#      ^^^^^^^^^^^^ source.elixir.embedded.surface meta.function-call.arguments.elixir
+#      ^^^^^^^^^^^^ source.elixir.embedded.html meta.function-call.arguments.elixir
 #   ^^^ keyword.control.loop.surface
-# ^^^^^^^^^^^^^^^^^^ meta.embedded.surface
+# ^^^^^^^^^^^^^^^^^^ meta.embedded.html
 
     <span id={@id} class={:icon, "has-text-warning": i <= value} style={@style}>
-#                                                                      ^^^^^^^^ meta.attribute-with-value.style.html meta.embedded.surface
-#                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class.html meta.embedded.surface
-#            ^^^^^ meta.attribute-with-value.id.html meta.embedded.surface
+#                                                                      ^^^^^^^^ meta.attribute-with-value.style.html meta.embedded.html
+#                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class.html meta.embedded.html
+#            ^^^^^ meta.attribute-with-value.id.html meta.embedded.html
 #         ^^ meta.tag.inline.any.html meta.attribute-with-value entity.other.attribute-name
       <i class="fas fa-{@icon_name}" />
 #              ^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class.html meta.string.html - meta.interpolation
     </span>
     {i + 1}
-#         ^ punctuation.section.embedded.end.surface - source
-#    ^^^^^ source.elixir.embedded.surface
-#   ^ punctuation.section.embedded.begin.surface - source
-#   ^^^^^^^ meta.embedded.surface
+#         ^ punctuation.section.embedded.end.html - source
+#    ^^^^^ source.elixir.embedded.html
+#   ^ punctuation.section.embedded.begin.html - source
+#   ^^^^^^^ meta.embedded.html
   {#else}
 #   ^^^^ keyword.control.conditional.surface
   {#elsei}
 #   ^^^^^ keyword.control.surface
   {#elseif x == 0}
-#                ^ punctuation.section.embedded.end.surface
-#          ^^^^^^ source.elixir.embedded.surface
+#                ^ punctuation.section.embedded.end.html
+#          ^^^^^^ source.elixir.embedded.html
 #   ^^^^^^ keyword.control.conditional.surface
-# ^^ punctuation.section.embedded.begin.surface
-# ^^^^^^^^^^^^^^^^ meta.embedded.surface
+# ^^ punctuation.section.embedded.begin.html
+# ^^^^^^^^^^^^^^^^ meta.embedded.html
   {/for}
-#      ^ punctuation.section.embedded.end.surface
+#      ^ punctuation.section.embedded.end.html
 #   ^^^ keyword.control.loop.surface
-# ^^ punctuation.section.embedded.begin.surface
-# ^^^^^^ meta.embedded.surface
+# ^^ punctuation.section.embedded.begin.html
+# ^^^^^^ meta.embedded.html
 </Rating>
 # ^^^^^^ entity.name.tag.end.surface
 
@@ -91,20 +91,20 @@
   {#case @value}
 #         ^^^^^ variable.other.constant.elixir
 #   ^^^^ keyword.control.conditional.surface
-#              ^ punctuation.section.embedded.end.surface
-# ^^punctuation.section.embedded.begin.surface
-# ^^^^^^^^^^^^^^ meta.embedded.surface
+#              ^ punctuation.section.embedded.end.html
+# ^^punctuation.section.embedded.begin.html
+# ^^^^^^^^^^^^^^ meta.embedded.html
     {#match [{_, first} | _]}
-#                           ^ punctuation.section.embedded.end.surface
+#                           ^ punctuation.section.embedded.end.html
 #                     ^ punctuation.section.sequence.end.elixir
 #                ^^^^^ variable.parameter.elixir
 #            ^ punctuation.section.sequence.begin.elixir
-#   ^^ punctuation.section.embedded.begin.surface
+#   ^^ punctuation.section.embedded.begin.html
       First {first}
-#                 ^ punctuation.section.embedded.end.surface - source
-#            ^^^^^ source.elixir.embedded.surface variable.other.elixir
-#           ^ punctuation.section.embedded.begin.surface - source
-#           ^^^^^^^ meta.embedded.surface
+#                 ^ punctuation.section.embedded.end.html - source
+#            ^^^^^ source.elixir.embedded.html variable.other.elixir
+#           ^ punctuation.section.embedded.begin.html - source
+#           ^^^^^^^ meta.embedded.html
     {#match []}
 #           ^^ meta.brackets.elixir
       Value is empty
@@ -123,26 +123,26 @@
 #^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.surface
 
 <Card {=@prop} prop={@prop}>
-#                         ^ punctuation.section.embedded.end.surface
+#                         ^ punctuation.section.embedded.end.html
 #                     ^^^^ variable.other.constant.elixir
 #                    ^ keyword.operator.attribute.elixir
-#                    ^^^^^ source.elixir.embedded.surface
-#                   ^ punctuation.section.embedded.begin.surface
+#                    ^^^^^ source.elixir.embedded.html
+#                   ^ punctuation.section.embedded.begin.html
 #                  ^ punctuation.separator.key-value.html
 #              ^^^^ entity.other.attribute-name.html
-#            ^ punctuation.section.embedded.end.surface
+#            ^ punctuation.section.embedded.end.html
 #        ^^^^ variable.other.constant.elixir
 #       ^ keyword.operator.attribute.elixir
 #      ^ keyword.operator.match.elixir
-#      ^^^^^^ source.elixir.embedded.surface
-#     ^ punctuation.section.embedded.begin.surface
+#      ^^^^^^ source.elixir.embedded.html
+#     ^ punctuation.section.embedded.begin.html
 </Card>
 
 <#slot :args={value: @value, max: @max} />
-#                                     ^ punctuation.section.embedded.end.surface
-#             ^^^^^^^^^^^^^^^^^^^^^^^^ source.elixir.embedded.surface
-#            ^ punctuation.section.embedded.begin.surface
-#            ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.id.html meta.embedded.surface - string
+#                                     ^ punctuation.section.embedded.end.html
+#             ^^^^^^^^^^^^^^^^^^^^^^^^ source.elixir.embedded.html
+#            ^ punctuation.section.embedded.begin.html
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.id.html meta.embedded.html - string
 #           ^ punctuation.separator.key-value.html
 #       ^^^^ entity.other.attribute-name.surface
 #      ^ punctuation.definition.attribute.begin.surface
@@ -182,9 +182,9 @@
   <#Markdown class="content" opts={x: "y"}>
 #                                         ^ punctuation.definition.tag.end.html
 #                                         ^ meta.tag.other.surface - meta.attribute-with-value
-#                                        ^ punctuation.section.embedded.end.surface - source
-#                                  ^^^^^^ source.elixir.embedded.surface
-#                                 ^ punctuation.section.embedded.begin.surface - source
+#                                        ^ punctuation.section.embedded.end.html - source
+#                                  ^^^^^^ source.elixir.embedded.html
+#                                 ^ punctuation.section.embedded.begin.html - source
 #                            ^^^^^^^^^^^^^ meta.tag.other.surface meta.attribute-with-value.html
 #                           ^ meta.tag.other.surface - meta.attribute-with-value
 #                  ^^^^^^^^^ string.quoted.double.html
@@ -226,15 +226,15 @@
 #                 ^^^^^^^^^ -entity
 #     ^^^^^^^^^ -entity
 <!-- This {comment} will be sent to the browser -->
-#                 ^ punctuation.section.embedded.end.surface - source
-#          ^^^^^^^ source.elixir.embedded.surface variable.other.elixir
-#         ^ punctuation.section.embedded.begin.surface - source
-#         ^^^^^^^^^ meta.embedded.surface
+#                 ^ punctuation.section.embedded.end.html - source
+#          ^^^^^^^ source.elixir.embedded.html variable.other.elixir
+#         ^ punctuation.section.embedded.begin.html - source
+#         ^^^^^^^^^ meta.embedded.html
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.html
  {!-- This {comment} won't be sent to the browser --}
 #                                                 ^^^ punctuation.definition.comment.end.surface
 #^^^^ punctuation.definition.comment.begin.surface
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.html.surface meta.embedded.surface comment.block.surface - source - variable
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.html.surface meta.embedded.html comment.block.surface - source - variable
 
 <tag{@a} />
 #   ^^^^ - source.elixir
@@ -242,16 +242,16 @@
 
 <{}}>{@x}</{}}>
 #          ^^^ entity.name.tag.end.html
-#     ^^ source.elixir.embedded.surface
+#     ^^ source.elixir.embedded.html
 #^^^ entity.name.tag.begin.html
 <...>{@x}</...>
 #          ^^^ entity.name.tag.end.html
-#     ^^ source.elixir.embedded.surface
+#     ^^ source.elixir.embedded.html
 #^^^ entity.name.tag.begin.html
 <{x}>{@x}</{x}>
 #          ^^^ entity.name.tag.end.html -source.elixir
 #      ^ variable.other.constant.elixir
-#     ^^ source.elixir.embedded.surface
+#     ^^ source.elixir.embedded.html
 #     ^ keyword.operator.attribute.elixir
 #^^^ entity.name.tag.begin.html -source.elixir
 

--- a/tests/syntax_test_template.sface
+++ b/tests/syntax_test_template.sface
@@ -4,52 +4,72 @@
 #                                        ^^^^^^^^^^ string.quoted.double
 #                                       ^ punctuation.separator.key-value
 #                                     ^^ entity
+#                                   ^ meta.string.html meta.interpolation.html punctuation.section.interpolation.end.elixir - source
 #                           ^^^^ constant.other.keyword
 #             ^^^^^^ constant.other.keyword
-#            ^^^^^^^^^^^^^^^^^^^^^^^^ source.elixir.interpolated.html
+#             ^^^^^^^^^^^^^^^^^^^^^^ meta.string.html meta.interpolation.html source.elixir.interpolated.html
+#            ^ meta.string.html meta.interpolation.html punctuation.section.interpolation.begin.elixir - source
 #^^^^^^ entity.name.tag.begin.surface
   {#for i <- 1..max}
-#      ^^^^^^^^^^^^ meta.function-call.arguments.elixir
-#   ^^^ entity.name.tag.block.surface
-# ^^^^^^^^^^^^^^^^^^ source.elixir.embedded.html
+#      ^^^^^^^^^^^^ source.elixir.embedded.html meta.function-call.arguments.elixir
+#   ^^^ keyword.control.loop.surface
+# ^^^^^^^^^^^^^^^^^^ meta.embedded.surface
     <span class={:icon, "has-text-warning": i <= value}>
       <i class="fas fa-{@icon_name}" />
+#                                  ^ meta.attribute-with-value.class.html meta.string.html - meta.interpolation
+#                                 ^ punctuation.section.interpolation.end.elixir - source
 #                        ^^^^^^^^^ variable.other.constant.elixir
 #                       ^ keyword.operator.attribute.elixir
-#                      ^^^^^^^^^^^^ source.elixir.interpolated.html
+#                       ^^^^^^^^^^ source.elixir.interpolated.html
+#                      ^ punctuation.section.interpolation.begin.elixir - source
+#                      ^^^^^^^^^^^^ meta.attribute-with-value.class.html meta.class-name.html meta.string.html meta.interpolation.html
+#              ^^^^^^^^ meta.attribute-with-value.class.html meta.string.html - meta.interpolation
     </span>
     {i + 1}
-#   ^^^^^^^ source.elixir.embedded.html
+#         ^ punctuation.section.interpolation.end.elixir - source
+#    ^^^^^ source.elixir.interpolated.html
+#   ^ punctuation.section.interpolation.begin.elixir - source
+#   ^^^^^^^ meta.interpolation.html
   {#else}
-#   ^^^^ entity.name.tag.block.surface
+#   ^^^^ keyword.control.conditional.surface
   {#elsei}
-#   ^^^^^ entity.name.tag.block.surface
+#   ^^^^^ keyword.control.surface
   {#elseif x == 0}
+#                ^ punctuation.section.embedded.end.surface
 #          ^^^^^^ source.elixir.embedded.html
-#   ^^^^^^ entity.name.tag.block.surface
+#   ^^^^^^ keyword.control.conditional.surface
+# ^^ punctuation.section.embedded.begin.surface
+# ^^^^^^^^^^^^^^^^ meta.embedded.surface
   {/for}
-#   ^^^ entity.name.tag.block.surface
+#      ^ punctuation.section.embedded.end.surface
+#   ^^^ keyword.control.loop.surface
+# ^^ punctuation.section.embedded.begin.surface
+# ^^^^^^ meta.embedded.surface
 </Rating>
 # ^^^^^^ entity.name.tag.end.surface
 
 <Some.component x={y} />
 #     ^^^^^^^^^ variable.function.surface -entity.name
+#^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.surface
 <Some.App.Component x={y}>
 #         ^^^^^^^^^ entity.name.tag.begin.surface
 #        ^ punctuation.accessor.dot.surface
 #     ^^^ entity.name.tag.begin.surface
 #    ^ punctuation.accessor.dot.surface
 #^^^^ entity.name.tag.begin.surface
+#^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.surface
   {#case @value}
     {#match [{_, first} | _]}
-#                           ^ punctuation.definition.tag.end.surface
+#                           ^ punctuation.section.embedded.end.surface
 #                     ^ punctuation.section.sequence.end.elixir
 #                ^^^^^ variable.parameter.elixir
 #            ^ punctuation.section.sequence.begin.elixir
-#   ^^ punctuation.definition.tag.begin.surface
+#   ^^ punctuation.section.embedded.begin.surface
       First {first}
-#            ^^^^^ variable.other.elixir
-#           ^^^^^^^ source.elixir.embedded.html
+#                 ^ punctuation.section.interpolation.end.elixir - source
+#            ^^^^^ source.elixir.interpolated.html variable.other.elixir
+#           ^ punctuation.section.interpolation.begin.elixir - source
+#           ^^^^^^^ meta.interpolation.html
     {#match []}
 #           ^^ meta.brackets.elixir
       Value is empty
@@ -65,37 +85,46 @@
 #      ^^^ entity.name.tag.end.surface
 #     ^ punctuation.accessor.dot.surface
 # ^^^^ entity.name.tag.end.surface
+#^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.surface
 
 <Card {=@prop} prop={@prop}>
 #                         ^ punctuation.section.interpolation.end.elixir
 #                     ^^^^ variable.other.constant.elixir
 #                    ^ keyword.operator.attribute.elixir
+#                    ^^^^^ source.elixir.interpolated.html
 #                   ^ punctuation.section.interpolation.begin.elixir
-#                   ^^^^^^^ source.elixir.interpolated.html
 #                  ^ punctuation.separator.key-value.html
 #              ^^^^ entity.other.attribute-name.html
 #            ^ punctuation.section.interpolation.end.elixir
 #        ^^^^ variable.other.constant.elixir
 #       ^ keyword.operator.attribute.elixir
 #      ^ keyword.operator.match.elixir
+#      ^^^^^^ source.elixir.interpolated.html
 #     ^ punctuation.section.interpolation.begin.elixir
-#     ^^^^^^^^ source.elixir.interpolated.html
 </Card>
 
 <#slot :args={value: @value, max: @max} />
-#            ^^^^^^^^^^^^^^^^^^^^^^^^^^ source.elixir.interpolated.html
+#                                     ^ punctuation.section.interpolation.end.elixir
+#             ^^^^^^^^^^^^^^^^^^^^^^^^ source.elixir.interpolated.html
+#            ^ punctuation.section.interpolation.begin.elixir
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.id.html meta.toc-list.id.html meta.string.html meta.interpolation.html - string
 #           ^ punctuation.separator.key-value.html
 #       ^^^^ entity.other.attribute-name.surface
+#      ^ punctuation.definition.attribute.begin.surface
+#      ^^^^^^ meta.tag.other.surface meta.attribute-with-value.id.html - meta.string - meta.interpolation
 #^^^^^ entity.name.tag.begin.surface
+#^^^^^^ meta.tag.other.surface - meta.attribute-with-value
 
 <:slot></:slot>
 #        ^^^^^ entity.name.tag.end.surface
 #^^^^^ entity.name.tag.begin.surface
+#^^^^^^^^^^^^^^ meta.tag.other.surface - meta.attribute-with-value
 
   <#Raw>
 #      ^ punctuation.definition.tag.end.html
 #  ^^^^ entity.name.tag.begin.surface
 # ^ punctuation.definition.tag.begin.html
+# ^^^^^^ meta.tag.other.surface - meta.attribute-with-value
   <#Raw>
 #      ^ -punctuation.definition.tag.end.html
 #  ^^^^ -entity.name.tag.begin.surface
@@ -112,26 +141,38 @@
 #       ^ punctuation.definition.tag.end.html
 #   ^^^^ entity.name.tag.end.surface
 # ^^ punctuation.definition.tag.begin.html
+# ^^^^^^^ meta.tag.other.surface - meta.attribute-with-value
 
   <#Markdown class="content" opts={x: "y"}>
 #                                         ^ punctuation.definition.tag.end.html
-#                                 ^^^^^^^^ source.elixir.interpolated.html
+#                                         ^ meta.tag.other.surface - meta.attribute-with-value
+#                                        ^ punctuation.section.interpolation.end.elixir - source
+#                                  ^^^^^^ source.elixir.interpolated.html
+#                                 ^ punctuation.section.interpolation.begin.elixir - source
+#                            ^^^^^^^^^^^^^ meta.tag.other.surface meta.attribute-with-value.html
+#                           ^ meta.tag.other.surface - meta.attribute-with-value
 #                  ^^^^^^^^^ string.quoted.double.html
+#            ^^^^^^^^^^^^^^^ meta.tag.other.surface meta.attribute-with-value.class.html
 #            ^^^^^ entity.other.attribute-name.class.html
 #  ^^^^^^^^^ entity.name.tag.begin.surface
 # ^ punctuation.definition.tag.begin.html
+# ^^^^^^^^^^^ meta.tag.other.surface - meta.attribute-with-value
   # Markdown
 <#Markdown>
 #^^^^^^^^^ -entity.name.tag.end.surface
 </#Markdown>
 # ^^^^^^^^^ entity.name.tag.end.surface
+#^^^^^^^^^^^ meta.tag.other.surface
+#           ^ - meta.tag
     <span></span>
 #           ^^^^ entity.name.tag.inline.any.html
 #    ^^^^ entity.name.tag.inline.any.html
   </#Markdown>
+#             ^ - meta.tag
 #            ^ punctuation.definition.tag.end.html
 #   ^^^^^^^^^ entity.name.tag.end.surface
 # ^^ punctuation.definition.tag.begin.surface
+# ^^^^^^^^^^^^ meta.tag.other.surface
 
 <style>
   .class {
@@ -149,31 +190,36 @@
 #                 ^^^^^^^^^ -entity
 #     ^^^^^^^^^ -entity
 <!-- This {comment} will be sent to the browser -->
-#          ^^^^^^^ variable.other.elixir
-#         ^^^^^^^^^ source.elixir.interpolated.html
+#                 ^ punctuation.section.interpolation.end.elixir - source
+#          ^^^^^^^ source.elixir.interpolated.html variable.other.elixir
+#         ^ punctuation.section.interpolation.begin.elixir - source
+#         ^^^^^^^^^ meta.interpolation.html
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.html
  {!-- This {comment} won't be sent to the browser --}
 #                                                 ^^^ punctuation.definition.comment.end.surface
-#           ^^^^^^^ -variable
-#          ^^^^^^^^^ -source.elixir.interpolated -source.elixir.embedded
 #^^^^ punctuation.definition.comment.begin.surface
-
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.html.surface meta.embedded.html comment.block.surface - source - variable
 
 <{}}>{@x}</{}}>
 #          ^^^ entity.name.tag.end.html
-#    ^^^^ source.elixir.embedded.html
+#     ^^ source.elixir.interpolated.html
 #^^^ entity.name.tag.begin.html
 <...>{@x}</...>
 #          ^^^ entity.name.tag.end.html
-#    ^^^^ source.elixir.embedded.html
+#     ^^ source.elixir.interpolated.html
 #^^^ entity.name.tag.begin.html
 <{x}>{@x}</{x}>
 #          ^^^ entity.name.tag.end.html -source.elixir
 #      ^ variable.other.constant.elixir
+#     ^^ source.elixir.interpolated.html
 #     ^ keyword.operator.attribute.elixir
-#    ^^^^ source.elixir.embedded.html
 #^^^ entity.name.tag.begin.html -source.elixir
 
 <.not_a_func>
 #^^^^^^^^^^^ entity.name.tag.begin.html -variable.function
 </.not_a_func>
 # ^^^^^^^^^^^ entity.name.tag.end.html -variable.function
+
+<div class={@my_class}>
+  Name: {String.upcase(@name)}
+</div>

--- a/tests/syntax_test_template.sface
+++ b/tests/syntax_test_template.sface
@@ -4,30 +4,30 @@
 #                                        ^^^^^^^^^^ string.quoted.double
 #                                       ^ punctuation.separator.key-value
 #                                     ^^ entity
-#                                   ^ meta.string.html meta.interpolation.html punctuation.section.interpolation.end.elixir - source
+#                                   ^ meta.string.html meta.embedded.surface punctuation.section.embedded.end.surface - source
 #                           ^^^^ constant.other.keyword
 #             ^^^^^^ constant.other.keyword
-#             ^^^^^^^^^^^^^^^^^^^^^^ meta.string.html meta.interpolation.html source.elixir.interpolated.html
-#            ^ meta.string.html meta.interpolation.html punctuation.section.interpolation.begin.elixir - source
+#             ^^^^^^^^^^^^^^^^^^^^^^ meta.string.html meta.embedded.surface source.elixir.embedded.surface
+#            ^ meta.string.html meta.embedded.surface punctuation.section.embedded.begin.surface - source
 #^^^^^^ entity.name.tag.begin.surface
   {#for i <- 1..max}
-#      ^^^^^^^^^^^^ source.elixir.embedded.html meta.function-call.arguments.elixir
+#      ^^^^^^^^^^^^ source.elixir.embedded.surface meta.function-call.arguments.elixir
 #   ^^^ keyword.control.loop.surface
 # ^^^^^^^^^^^^^^^^^^ meta.embedded.surface
     <span class={:icon, "has-text-warning": i <= value}>
       <i class="fas fa-{@icon_name}" />
 #                                  ^ meta.attribute-with-value.class.html meta.string.html - meta.interpolation
-#                                 ^ punctuation.section.interpolation.end.elixir - source
+#                                 ^ punctuation.section.embedded.end.surface - source
 #                        ^^^^^^^^^ variable.other.constant.elixir
 #                       ^ keyword.operator.attribute.elixir
-#                       ^^^^^^^^^^ source.elixir.interpolated.html
-#                      ^ punctuation.section.interpolation.begin.elixir - source
-#                      ^^^^^^^^^^^^ meta.attribute-with-value.class.html meta.class-name.html meta.string.html meta.interpolation.html
+#                       ^^^^^^^^^^ source.elixir.embedded.surface
+#                      ^ punctuation.section.embedded.begin.surface - source
+#                      ^^^^^^^^^^^^ meta.attribute-with-value.class.html meta.class-name.html meta.string.html meta.embedded.surface
 #              ^^^^^^^^ meta.attribute-with-value.class.html meta.string.html - meta.interpolation
     </span>
     {i + 1}
 #         ^ punctuation.section.embedded.end.surface - source
-#    ^^^^^ source.elixir.embedded.html
+#    ^^^^^ source.elixir.embedded.surface
 #   ^ punctuation.section.embedded.begin.surface - source
 #   ^^^^^^^ meta.embedded.surface
   {#else}
@@ -36,7 +36,7 @@
 #   ^^^^^ keyword.control.surface
   {#elseif x == 0}
 #                ^ punctuation.section.embedded.end.surface
-#          ^^^^^^ source.elixir.embedded.html
+#          ^^^^^^ source.elixir.embedded.surface
 #   ^^^^^^ keyword.control.conditional.surface
 # ^^ punctuation.section.embedded.begin.surface
 # ^^^^^^^^^^^^^^^^ meta.embedded.surface
@@ -72,7 +72,7 @@
 #   ^^ punctuation.section.embedded.begin.surface
       First {first}
 #                 ^ punctuation.section.embedded.end.surface - source
-#            ^^^^^ source.elixir.embedded.html variable.other.elixir
+#            ^^^^^ source.elixir.embedded.surface variable.other.elixir
 #           ^ punctuation.section.embedded.begin.surface - source
 #           ^^^^^^^ meta.embedded.surface
     {#match []}
@@ -93,26 +93,26 @@
 #^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.surface
 
 <Card {=@prop} prop={@prop}>
-#                         ^ punctuation.section.interpolation.end.elixir
+#                         ^ punctuation.section.embedded.end.surface
 #                     ^^^^ variable.other.constant.elixir
 #                    ^ keyword.operator.attribute.elixir
-#                    ^^^^^ source.elixir.interpolated.html
-#                   ^ punctuation.section.interpolation.begin.elixir
+#                    ^^^^^ source.elixir.embedded.surface
+#                   ^ punctuation.section.embedded.begin.surface
 #                  ^ punctuation.separator.key-value.html
 #              ^^^^ entity.other.attribute-name.html
-#            ^ punctuation.section.interpolation.end.elixir
+#            ^ punctuation.section.embedded.end.surface
 #        ^^^^ variable.other.constant.elixir
 #       ^ keyword.operator.attribute.elixir
 #      ^ keyword.operator.match.elixir
-#      ^^^^^^ source.elixir.interpolated.html
-#     ^ punctuation.section.interpolation.begin.elixir
+#      ^^^^^^ source.elixir.embedded.surface
+#     ^ punctuation.section.embedded.begin.surface
 </Card>
 
 <#slot :args={value: @value, max: @max} />
-#                                     ^ punctuation.section.interpolation.end.elixir
-#             ^^^^^^^^^^^^^^^^^^^^^^^^ source.elixir.interpolated.html
-#            ^ punctuation.section.interpolation.begin.elixir
-#            ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.id.html meta.toc-list.id.html meta.string.html meta.interpolation.html - string
+#                                     ^ punctuation.section.embedded.end.surface
+#             ^^^^^^^^^^^^^^^^^^^^^^^^ source.elixir.embedded.surface
+#            ^ punctuation.section.embedded.begin.surface
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.id.html meta.toc-list.id.html meta.string.html meta.embedded.surface - string
 #           ^ punctuation.separator.key-value.html
 #       ^^^^ entity.other.attribute-name.surface
 #      ^ punctuation.definition.attribute.begin.surface
@@ -151,9 +151,9 @@
   <#Markdown class="content" opts={x: "y"}>
 #                                         ^ punctuation.definition.tag.end.html
 #                                         ^ meta.tag.other.surface - meta.attribute-with-value
-#                                        ^ punctuation.section.interpolation.end.elixir - source
-#                                  ^^^^^^ source.elixir.interpolated.html
-#                                 ^ punctuation.section.interpolation.begin.elixir - source
+#                                        ^ punctuation.section.embedded.end.surface - source
+#                                  ^^^^^^ source.elixir.embedded.surface
+#                                 ^ punctuation.section.embedded.begin.surface - source
 #                            ^^^^^^^^^^^^^ meta.tag.other.surface meta.attribute-with-value.html
 #                           ^ meta.tag.other.surface - meta.attribute-with-value
 #                  ^^^^^^^^^ string.quoted.double.html
@@ -195,28 +195,28 @@
 #                 ^^^^^^^^^ -entity
 #     ^^^^^^^^^ -entity
 <!-- This {comment} will be sent to the browser -->
-#                 ^ punctuation.section.interpolation.end.elixir - source
-#          ^^^^^^^ source.elixir.interpolated.html variable.other.elixir
-#         ^ punctuation.section.interpolation.begin.elixir - source
-#         ^^^^^^^^^ meta.interpolation.html
+#                 ^ punctuation.section.embedded.end.surface - source
+#          ^^^^^^^ source.elixir.embedded.surface variable.other.elixir
+#         ^ punctuation.section.embedded.begin.surface - source
+#         ^^^^^^^^^ meta.embedded.surface
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.html
  {!-- This {comment} won't be sent to the browser --}
 #                                                 ^^^ punctuation.definition.comment.end.surface
 #^^^^ punctuation.definition.comment.begin.surface
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.html.surface meta.embedded.html comment.block.surface - source - variable
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ text.html.surface meta.embedded.surface comment.block.surface - source - variable
 
 <{}}>{@x}</{}}>
 #          ^^^ entity.name.tag.end.html
-#     ^^ source.elixir.embedded.html
+#     ^^ source.elixir.embedded.surface
 #^^^ entity.name.tag.begin.html
 <...>{@x}</...>
 #          ^^^ entity.name.tag.end.html
-#     ^^ source.elixir.embedded.html
+#     ^^ source.elixir.embedded.surface
 #^^^ entity.name.tag.begin.html
 <{x}>{@x}</{x}>
 #          ^^^ entity.name.tag.end.html -source.elixir
 #      ^ variable.other.constant.elixir
-#     ^^ source.elixir.embedded.html
+#     ^^ source.elixir.embedded.surface
 #     ^ keyword.operator.attribute.elixir
 #^^^ entity.name.tag.begin.html -source.elixir
 

--- a/tests/syntax_test_template.sface
+++ b/tests/syntax_test_template.sface
@@ -38,7 +38,12 @@
 #      ^^^^^^^^^^^^ source.elixir.embedded.surface meta.function-call.arguments.elixir
 #   ^^^ keyword.control.loop.surface
 # ^^^^^^^^^^^^^^^^^^ meta.embedded.surface
-    <span class={:icon, "has-text-warning": i <= value}>
+
+    <span id={@id} class={:icon, "has-text-warning": i <= value} style={@style}>
+#                                                                      ^^^^^^^^ meta.attribute-with-value.html meta.embedded.surface
+#                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class.html meta.embedded.surface
+#            ^^^^^ meta.attribute-with-value.id.html meta.embedded.surface
+#         ^^ meta.tag.inline.any.html meta.attribute-with-value entity.other.attribute-name
       <i class="fas fa-{@icon_name}" />
 #                                  ^ meta.attribute-with-value.class.html meta.string.html - meta.interpolation
 #                                 ^ punctuation.section.embedded.end.surface - source

--- a/tests/syntax_test_template.sface
+++ b/tests/syntax_test_template.sface
@@ -1,38 +1,46 @@
 # SYNTAX TEST "HTML (Surface).sublime-syntax"
 
 <html lang="{"en"}" lang={"en"}>
-<!--                           ^ punctuation.definition.tag.end.html -->
-<!--             ^ punctuation.section.embedded.end.surface -->
-<!--         ^^^^ string.quoted.double.elixir -->
-<!--        ^ punctuation.section.embedded.begin.surface -->
-<!--       ^ punctuation.definition.string.begin.html -->
+#                              ^ punctuation.definition.tag.end.html
+#                             ^ punctuation.section.embedded.end.surface
+#                         ^^^^ source.elixir.embedded.surface meta.string.elixir string.quoted.double.elixir
+#                        ^^^^^^ meta.attribute-with-value.html meta.embedded.surface
+#                        ^ punctuation.section.embedded.begin.surface
+#                       ^ punctuation.separator.key-value.html
+#                   ^^^^ entity.other.attribute-name.html
+#                 ^ invalid.illegal.attribute-name.html
+#               ^ invalid.illegal.attribute-name.html
+#             ^^^^^ entity.other.attribute-name.html
+#            ^ punctuation.definition.string.end.html
+#          ^^^ meta.string.html string.quoted.double.html
+#          ^ punctuation.definition.string.begin.html
 
 <!-- HTML comment with {"embedded"} ?? -->
-<!--                              ^ punctuation.section.embedded.end.surface - source -->
-<!--                    ^^^^^^^^^^ source.elixir.embedded.surface -->
-<!--                   ^ punctuation.section.embedded.begin.surface - source -->
-<!--                   ^^^^^^^^^^^^ comment.block.html meta.embedded.surface -->
+#                                 ^ punctuation.section.embedded.end.surface - source
+#                       ^^^^^^^^^^ source.elixir.embedded.surface
+#                      ^ punctuation.section.embedded.begin.surface - source
+#                      ^^^^^^^^^^^^ comment.block.html meta.embedded.surface
 
      <%# Comment %>
-<!--              ^ punctuation.definition.tag.end.html -->
-<!--             ^ entity.other.attribute-name -->
-<!--     ^^^^^^^ entity.other.attribute-name -->
-<!--  ^^ entity.name.tag -->
-<!-- ^ punctuation.definition.tag.begin.html -->
-<!-- ^^^^^^^^^^^^^^ meta.tag - meta.embedded - comment -->
+#                 ^ punctuation.definition.tag.end.html
+#                ^ entity.other.attribute-name
+#        ^^^^^^^ entity.other.attribute-name
+#     ^^ entity.name.tag
+#    ^ punctuation.definition.tag.begin.html
+#    ^^^^^^^^^^^^^^ meta.tag - meta.embedded - comment
 
      <br class="<%# Comment %>" />
-<!--           ^^^^^^^^^^^^^^^^ meta.string.html string.quoted.double.html - meta.embedded - comment -->
+#              ^^^^^^^^^^^^^^^^ meta.string.html string.quoted.double.html - meta.embedded - comment
 
 <Rating :let={value: value, max: max} id="rating_2">
 #                                        ^^^^^^^^^^ string.quoted.double
 #                                       ^ punctuation.separator.key-value
 #                                     ^^ entity
-#                                   ^ meta.string.html meta.embedded.surface punctuation.section.embedded.end.surface - source
+#                                   ^ meta.embedded.surface punctuation.section.embedded.end.surface - source
 #                           ^^^^ constant.other.keyword
 #             ^^^^^^ constant.other.keyword
-#             ^^^^^^^^^^^^^^^^^^^^^^ meta.string.html meta.embedded.surface source.elixir.embedded.surface
-#            ^ meta.string.html meta.embedded.surface punctuation.section.embedded.begin.surface - source
+#             ^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.surface source.elixir.embedded.surface
+#            ^ meta.embedded.surface punctuation.section.embedded.begin.surface - source
 #^^^^^^ entity.name.tag.begin.surface
   {#for i <- 1..max}
 #      ^^^^^^^^^^^^ source.elixir.embedded.surface meta.function-call.arguments.elixir
@@ -40,19 +48,12 @@
 # ^^^^^^^^^^^^^^^^^^ meta.embedded.surface
 
     <span id={@id} class={:icon, "has-text-warning": i <= value} style={@style}>
-#                                                                      ^^^^^^^^ meta.attribute-with-value.html meta.embedded.surface
+#                                                                      ^^^^^^^^ meta.attribute-with-value.style.html meta.embedded.surface
 #                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class.html meta.embedded.surface
 #            ^^^^^ meta.attribute-with-value.id.html meta.embedded.surface
 #         ^^ meta.tag.inline.any.html meta.attribute-with-value entity.other.attribute-name
       <i class="fas fa-{@icon_name}" />
-#                                  ^ meta.attribute-with-value.class.html meta.string.html - meta.interpolation
-#                                 ^ punctuation.section.embedded.end.surface - source
-#                        ^^^^^^^^^ variable.other.constant.elixir
-#                       ^ keyword.operator.attribute.elixir
-#                       ^^^^^^^^^^ source.elixir.embedded.surface
-#                      ^ punctuation.section.embedded.begin.surface - source
-#                      ^^^^^^^^^^^^ meta.attribute-with-value.class.html meta.class-name.html meta.string.html meta.embedded.surface
-#              ^^^^^^^^ meta.attribute-with-value.class.html meta.string.html - meta.interpolation
+#              ^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.class.html meta.string.html - meta.interpolation
     </span>
     {i + 1}
 #         ^ punctuation.section.embedded.end.surface - source
@@ -141,7 +142,7 @@
 #                                     ^ punctuation.section.embedded.end.surface
 #             ^^^^^^^^^^^^^^^^^^^^^^^^ source.elixir.embedded.surface
 #            ^ punctuation.section.embedded.begin.surface
-#            ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.id.html meta.toc-list.id.html meta.string.html meta.embedded.surface - string
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.id.html meta.embedded.surface - string
 #           ^ punctuation.separator.key-value.html
 #       ^^^^ entity.other.attribute-name.surface
 #      ^ punctuation.definition.attribute.begin.surface

--- a/tests/syntax_test_template.sface
+++ b/tests/syntax_test_template.sface
@@ -138,6 +138,21 @@
 #     ^ punctuation.section.embedded.begin.html
 </Card>
 
+<:slot></:slot>
+#        ^^^^^ entity.name.tag.end.surface
+#^^^^^ entity.name.tag.begin.surface
+#^^^^^^^^^^^^^^ meta.tag.other.surface - meta.attribute-with-value
+
+<.table rows={@users}></.table>
+#                             ^ punctuation.definition.tag.end.html
+#                       ^^^^^^ entity.name.tag.end.html
+#                     ^^ punctuation.definition.tag.begin.html
+#                     ^^^^^^^^^ meta.tag.other.surface
+#                    ^ meta.tag.other.surface punctuation.definition.tag.end.html
+#            ^^^^^^^^ meta.tag.other.surface meta.attribute-with-value.html meta.embedded.html
+#       ^^^^^ meta.tag.other.surface meta.attribute-with-value.html - meta.embedded
+#^^^^^^ meta.tag.other.surface entity.name.tag.begin.html
+
 <#slot :args={value: @value, max: @max} />
 #                                     ^ punctuation.section.embedded.end.html
 #             ^^^^^^^^^^^^^^^^^^^^^^^^ source.elixir.embedded.html
@@ -149,11 +164,6 @@
 #      ^^^^^^ meta.tag.other.surface meta.attribute-with-value.id.html - meta.string - meta.interpolation
 #^^^^^ entity.name.tag.begin.surface
 #^^^^^^ meta.tag.other.surface - meta.attribute-with-value
-
-<:slot></:slot>
-#        ^^^^^ entity.name.tag.end.surface
-#^^^^^ entity.name.tag.begin.surface
-#^^^^^^^^^^^^^^ meta.tag.other.surface - meta.attribute-with-value
 
   <#Raw>
 #      ^ punctuation.definition.tag.end.html

--- a/tests/syntax_test_template.sface
+++ b/tests/syntax_test_template.sface
@@ -26,10 +26,10 @@
 #              ^^^^^^^^ meta.attribute-with-value.class.html meta.string.html - meta.interpolation
     </span>
     {i + 1}
-#         ^ punctuation.section.interpolation.end.elixir - source
-#    ^^^^^ source.elixir.interpolated.html
-#   ^ punctuation.section.interpolation.begin.elixir - source
-#   ^^^^^^^ meta.interpolation.html
+#         ^ punctuation.section.embedded.end.surface - source
+#    ^^^^^ source.elixir.embedded.html
+#   ^ punctuation.section.embedded.begin.surface - source
+#   ^^^^^^^ meta.embedded.surface
   {#else}
 #   ^^^^ keyword.control.conditional.surface
   {#elsei}
@@ -59,6 +59,11 @@
 #^^^^ entity.name.tag.begin.surface
 #^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.other.surface
   {#case @value}
+#         ^^^^^ variable.other.constant.elixir
+#   ^^^^ keyword.control.conditional.surface
+#              ^ punctuation.section.embedded.end.surface
+# ^^punctuation.section.embedded.begin.surface
+# ^^^^^^^^^^^^^^ meta.embedded.surface
     {#match [{_, first} | _]}
 #                           ^ punctuation.section.embedded.end.surface
 #                     ^ punctuation.section.sequence.end.elixir
@@ -66,10 +71,10 @@
 #            ^ punctuation.section.sequence.begin.elixir
 #   ^^ punctuation.section.embedded.begin.surface
       First {first}
-#                 ^ punctuation.section.interpolation.end.elixir - source
-#            ^^^^^ source.elixir.interpolated.html variable.other.elixir
-#           ^ punctuation.section.interpolation.begin.elixir - source
-#           ^^^^^^^ meta.interpolation.html
+#                 ^ punctuation.section.embedded.end.surface - source
+#            ^^^^^ source.elixir.embedded.html variable.other.elixir
+#           ^ punctuation.section.embedded.begin.surface - source
+#           ^^^^^^^ meta.embedded.surface
     {#match []}
 #           ^^ meta.brackets.elixir
       Value is empty
@@ -202,16 +207,16 @@
 
 <{}}>{@x}</{}}>
 #          ^^^ entity.name.tag.end.html
-#     ^^ source.elixir.interpolated.html
+#     ^^ source.elixir.embedded.html
 #^^^ entity.name.tag.begin.html
 <...>{@x}</...>
 #          ^^^ entity.name.tag.end.html
-#     ^^ source.elixir.interpolated.html
+#     ^^ source.elixir.embedded.html
 #^^^ entity.name.tag.begin.html
 <{x}>{@x}</{x}>
 #          ^^^ entity.name.tag.end.html -source.elixir
 #      ^ variable.other.constant.elixir
-#     ^^ source.elixir.interpolated.html
+#     ^^ source.elixir.embedded.html
 #     ^ keyword.operator.attribute.elixir
 #^^^ entity.name.tag.begin.html -source.elixir
 
@@ -219,7 +224,3 @@
 #^^^^^^^^^^^ entity.name.tag.begin.html -variable.function
 </.not_a_func>
 # ^^^^^^^^^^^ entity.name.tag.end.html -variable.function
-
-<div class={@my_class}>
-  Name: {String.upcase(@name)}
-</div>

--- a/tests/syntax_test_template.sface
+++ b/tests/syntax_test_template.sface
@@ -1,5 +1,29 @@
 # SYNTAX TEST "HTML (Surface).sublime-syntax"
 
+<html lang="{"en"}" lang={"en"}>
+<!--                           ^ punctuation.definition.tag.end.html -->
+<!--             ^ punctuation.section.embedded.end.surface -->
+<!--         ^^^^ string.quoted.double.elixir -->
+<!--        ^ punctuation.section.embedded.begin.surface -->
+<!--       ^ punctuation.definition.string.begin.html -->
+
+<!-- HTML comment with {"embedded"} ?? -->
+<!--                              ^ punctuation.section.embedded.end.surface - source -->
+<!--                    ^^^^^^^^^^ source.elixir.embedded.surface -->
+<!--                   ^ punctuation.section.embedded.begin.surface - source -->
+<!--                   ^^^^^^^^^^^^ comment.block.html meta.embedded.surface -->
+
+     <%# Comment %>
+<!--              ^ punctuation.definition.tag.end.html -->
+<!--             ^ entity.other.attribute-name -->
+<!--     ^^^^^^^ entity.other.attribute-name -->
+<!--  ^^ entity.name.tag -->
+<!-- ^ punctuation.definition.tag.begin.html -->
+<!-- ^^^^^^^^^^^^^^ meta.tag - meta.embedded - comment -->
+
+     <br class="<%# Comment %>" />
+<!--           ^^^^^^^^^^^^^^^^ meta.string.html string.quoted.double.html - meta.embedded - comment -->
+
 <Rating :let={value: value, max: max} id="rating_2">
 #                                        ^^^^^^^^^^ string.quoted.double
 #                                       ^ punctuation.separator.key-value


### PR DESCRIPTION
The recent syntax changes look very good and have a nice and clean structure.

Here are some ideas and proposals for HTML (EEx).

What needs consideration is embedding code in strings/attribute values needs slightly different handling than embedded code in other locations of HTML. The reason is the string scope which needs to be cleared so embedded code gets correctly highlighted and auto completion is enabled. On the other hand we don't want to clear any scopes if code is embedded outside of strings as this would very likely clear the main scope of the syntax. That's not desirable.

To achieve that two types of "embedded" contexts are required. There's no real guideline at the moment, but we may probably call normally embedded contexts "embedded" and those in strings "interpolation". We might also use interpolation vs. string-interpolation or something along those lines.

I haven't had a look at the other syntaxes of this packages, but I personally find it a bit strange to call `<%` a tag. With regards to ASP/JSP/PHP I'd suggest to scope all of `<%` and `%>` `punctuation.section.embedded`. 

Some more comments about this can be found in commit messages.

Disclaimer: You asked for comments ;-)